### PR TITLE
(SIMP-267) Test IPv6 client_nets with iptables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,112 @@
 ---
 language: ruby
 cache: bundler
+fast_finish: true
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
-script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+script: bundle exec rake test
+env:
+  - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.3.0"
+  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.0.0"
+  - PUPPET_VERSION="~> 4.1.0"
+
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env:
+      - PUPPET_VERSION="~> 2.7.0"
+      - PUPPET_VERSION="~> 3.2.0"
+      - PUPPET_VERSION="~> 3.3.0"
+      - PUPPET_VERSION="~> 3.4.0"
+      - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+      - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+      - PUPPET_VERSION="~> 4.0.0"
+      - PUPPET_VERSION="~> 4.1.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.3.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+
+  # Ruby 1.9.3
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 2.7.0"
+
+  # Ruby 2.0.0
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.3.0"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.3.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 2.7.0"
+  # - No Ruby 2.2 for ~>3.X: https://tickets.puppetlabs.com/browse/PUP-3796
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.3.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes

--- a/manifests/add_udp_listen.pp
+++ b/manifests/add_udp_listen.pp
@@ -74,6 +74,8 @@ define iptables::add_udp_listen (
 #     'any' to allow all networks
   $client_nets = '127.0.0.1'
 ) {
+  validate_net_list($client_nets,'^(any|ALL)$')
+
   $l_protocol = 'udp'
 
   iptables_rule { "udp_${name}":
@@ -83,6 +85,4 @@ define iptables::add_udp_listen (
     apply_to => $apply_to,
     content  => template('iptables/allow_tcp_udp_services.erb')
   }
-
-  validate_net_list($client_nets,'^(any|ALL)$')
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,7 +110,7 @@ class iptables (
   }
 
   file { '/etc/sysconfig/iptables':
-    ensure  => 'present',
+    ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0640',

--- a/spec/acceptance/add_tcp_stateful_listen_spec.rb
+++ b/spec/acceptance/add_tcp_stateful_listen_spec.rb
@@ -17,7 +17,7 @@ describe 'iptables' do
 
 
       iptables::add_tcp_stateful_listen { 'test_tcp_on_both':
-        client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
+        client_nets => ['10.0.2.0/16', 'fe80::/64'],  # Standard Beaker/Vagrant subnet
         dports      => '2222',
         apply_to    => 'all',
       }
@@ -28,11 +28,11 @@ describe 'iptables' do
         apply_to    => 'ipv4',
       }
 
-      ### iptables::add_tcp_stateful_listen { 'test_tcp_on_ipv6':
-      ###   client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
-      ###   dports      => '6666',
-      ###   apply_to    => 'ipv6',
-      ### }
+      iptables::add_tcp_stateful_listen { 'test_tcp_on_ipv6':
+        client_nets => ['fe80::/64'],  # Standard Beaker/Vagrant subnet
+        dports      => '6666',
+        apply_to    => 'ipv6',
+      }
     EOS
   }
 
@@ -44,16 +44,16 @@ describe 'iptables' do
     shell("iptables-save   | grep ' -p tcp' | grep -w 2222", :acceptable_exit_codes => 0)
   end
 
-  ### it 'should allow port 2222 for IPv6' do
-  ###   shell("ip6tables-save  | grep ' -p tcp' | grep -w 2222", :acceptable_exit_codes => 0)
-  ### end
+  it 'should allow port 2222 for IPv6' do
+    shell("ip6tables-save  | grep ' -p tcp' | grep -w 2222", :acceptable_exit_codes => 0)
+  end
 
   it 'should allow port 4444 for IPv4' do
     shell("iptables-save   | grep ' -p tcp' | grep -w 4444", :acceptable_exit_codes => 0)
   end
 
-  ### it 'should allow port 6666 for IPv6' do
-  ###   shell("ip6tables-save  | grep ' -p tcp' | grep -w 6666", :acceptable_exit_codes => 0)
-  ### end
+  it 'should allow port 6666 for IPv6' do
+    shell("ip6tables-save  | grep ' -p tcp' | grep -w 6666", :acceptable_exit_codes => 0)
+  end
 end
 

--- a/spec/classes/base_rules_spec.rb
+++ b/spec/classes/base_rules_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'iptables::base_rules' do
+
+  context  'on supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts) do
+        facts
+      end
+
+      context "on #{os}" do
+        context "iptables::base_rules class without any parameters" do
+          let(:params) {{ }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('iptables::base_rules') }
+          it { is_expected.to create_iptables_rule('global').with_apply_to('all') }
+          it { is_expected.to create_iptables_rule('allow_lo').with_apply_to('all') }
+          it { is_expected.to create_iptables_rule('allow_v4_echo_request').with_apply_to('ipv4') }
+          it { is_expected.to create_iptables_rule('drop_all').with_apply_to('all') }
+          it { is_expected.to create_iptables_rule('drop_broadcast').with_apply_to('ipv4') }
+          it { is_expected.to create_iptables_rule('drop_v6_broadcast').with_apply_to('ipv6') }
+          it { is_expected.to create_iptables_rule('drop_v4_multicast').with_apply_to('ipv4')}
+          it { is_expected.to create_iptables_rule('drop_v6_multicast').with_apply_to('ipv6') }
+          it { is_expected.to create_iptables_rule('established_related').with_apply_to('all') }
+          it { is_expected.to create_iptables_rule('log_all').with_apply_to('all') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'iptables' do
-
   context  'supported operating systems' do
     on_supported_os.each do |os, facts|
       let(:facts) do
@@ -13,8 +12,15 @@ describe 'iptables' do
           let(:params) {{ }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('iptables').with_disable(false) }
-          it { is_expected.to create_iptables_rule('global') }
+          it { is_expected.to contain_package('iptables').with_ensure('latest') }
+          it { is_expected.to contain_service('iptables').with_ensure('running') }
+          it { is_expected.to contain_service('iptables-retry').with_enable(true) }
+          it { is_expected.to create_class('iptables::base_rules').with_allow_ping(true) }
           it { is_expected.to create_iptables_optimize('/etc/sysconfig/iptables').with_disable(false) }
+          it { is_expected.to create_file('/etc/init.d/iptables').with_ensure('file') }
+          it { is_expected.to create_file('/etc/init.d/iptables-retry').with_ensure('file') }
+          it { is_expected.to create_file('/etc/sysconfig/iptables').with_ensure('file') }
+          it { is_expected.to contain_service('firewalld').with_ensure('stopped') }
         end
 
         context "iptables class with firewall disabled from hiera via 'use_iptables: false'" do
@@ -27,9 +33,5 @@ describe 'iptables' do
         end
       end
     end
-  end
-
-  it 'implements rules correctly' do
-    skip 'TODO: WRITE TESTS FOR IPTABLES RULES!'
   end
 end

--- a/spec/defines/add_tcp_stateful_listen_spec.rb
+++ b/spec/defines/add_tcp_stateful_listen_spec.rb
@@ -6,13 +6,24 @@ describe "iptables::add_tcp_stateful_listen", :type => :define do
           facts
         end
 
-        context "with client_nets in CIDR format" do
+        context "with client_nets in IPv4 CIDR format" do
           let( :title  ){ 'allow_tcp_1234' }
           let( :params ){{
             :client_nets => ['10.0.2.0/24'],
             :dports      => '1234'
           }}
           it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_tcp_1234').with_dports('1234') }
+        end
+
+        context "with client_nets in IPv6 CIDR format" do
+          let( :title  ){ 'allow_tcp_1234' }
+          let( :params ){{
+            :client_nets => ['fe80::/64'],
+            :dports      => '1234',
+            :apply_to    => 'ipv6'
+          }}
+          it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_tcp_1234').with_dports('1234') }
+          it { is_expected.to create_iptables_rule('tcp_allow_tcp_1234') }
         end
       end
     end

--- a/spec/defines/add_udp_listen_spec.rb
+++ b/spec/defines/add_udp_listen_spec.rb
@@ -1,0 +1,57 @@
+describe "iptables::add_udp_listen", :type => :define do
+  context  'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        describe "with IPv4 client_nets" do
+          let( :title  ){ 'allow_udp_1234' }
+          let( :params ){{
+            :client_nets => ['10.0.2.0'],
+            :dports      => '1234'
+          }}
+          it { is_expected.to create_iptables__add_udp_listen('allow_udp_1234').with_dports('1234') }
+        end
+
+        describe "with IPv4 client_netsi in CIDR notation" do
+          let( :title  ){ 'allow_udp_1234' }
+          let( :params ){{
+            :client_nets => ['10.0.2.0/24'],
+            :dports      => '1234'
+          }}
+          it { is_expected.to create_iptables__add_udp_listen('allow_udp_1234').with_dports('1234') }
+        end
+
+        describe "with IPv6 client_nets" do
+          let( :title  ){ 'allow_udp_1234' }
+          let( :params ){{
+            :client_nets => ['fe80::'],
+            :dports      => '1234',
+            :apply_to    => 'ipv6'
+          }}
+          it { is_expected.to create_iptables__add_udp_listen('allow_udp_1234').with_dports('1234') }
+          it { is_expected.to create_iptables_rule('udp_allow_udp_1234') }
+        end
+
+        describe "with IPv6 client_nets in CIDR format" do
+          let( :title  ){ 'allow_udp_1234' }
+          let( :params ){{
+            :client_nets => ['fe80::/64'],
+            :dports      => '1234',
+            :apply_to    => 'ipv6'
+          }}
+          it{
+            skip( 'FIXME: validate_net_list() fails *any* IPv6 CIDR (but accepts IPv4)' )
+            is_expected.to create_iptables__add_udp_listen('allow_udp_1234').with_dports('1234')
+          }
+          it{
+            skip( 'FIXME: validate_net_list() fails *any* IPv6 CIDR (but accepts IPv4)' )
+            is_expected.to create_iptables_rule('udp_allow_udp_1234')
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The acceptance tests for iptables::add_tcp_stateful_listen didn't
include IPv6.  This patch provides those tests (which pass).

SIMP-267 #close