### PR TITLE
(SIMP-45) Prevent IPv6 ::1 spoofed addresses

### DIFF
--- a/build/pupmod-iptables.spec
+++ b/build/pupmod-iptables.spec
@@ -1,7 +1,7 @@
 Summary: IPTables Puppet Module
 Name: pupmod-iptables
 Version: 4.1.0
-Release: 12
+Release: 13
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -71,6 +71,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Jul 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-13
+- Added an iptables::prevent_localhost_spoofing class to handle IPv6 spoofed
+  communication.
+
 * Wed Jul 08 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.0-12
 - Updated iptables::disable's default to look up 'use_iptables' from hiera.
 - Fixed iptables::disable to disable management of IPv4 rules.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,12 @@
 #   block anyone connecting to the system for an hour after connection to a
 #   forbidden port.
 #
+# [*prevent_localhost_spoofing*]
+# Type: Boolean
+# Default: true
+#   If true, add rules to PREROUTING that will prevent spoofed packets from
+#   localhost addresses from reaching your system.
+#
 # [*disable*]
 # Type: Boolean
 # Default: false
@@ -74,7 +80,8 @@ class iptables (
   $ignore               = [],
   $enable_default_rules = true,
   $enable_scanblock     = false,
-  $disable              = !hiera( 'use_iptables', true )
+  $prevent_localhost_spoofing = true,
+  $disable              = !hiera('use_iptables', true)
 ) {
   validate_bool($authoritative)
   validate_bool($class_debug)
@@ -82,10 +89,12 @@ class iptables (
   validate_array($ignore)
   validate_bool($enable_default_rules)
   validate_bool($enable_scanblock)
+  validate_bool($prevent_localhost_spoofing)
   validate_bool($disable)
 
-  if $enable_default_rules { include 'iptables::base_rules' }
-  if $enable_scanblock { include 'iptables::scanblock' }
+  if $enable_default_rules { include '::iptables::base_rules' }
+  if $enable_scanblock { include '::iptables::scanblock' }
+  if $prevent_localhost_spoofing { include '::iptables::prevent_localhost_spoofing' }
 
   # IPV4-only stuff
   file { '/etc/init.d/iptables':

--- a/manifests/prevent_localhost_spoofing.pp
+++ b/manifests/prevent_localhost_spoofing.pp
@@ -1,0 +1,24 @@
+# == Class: iptables::prevent_localhost_spoofing
+#
+# This adds some rules that prevent external parties from being able to send
+# spoofed packets to your system from ::1.
+#
+# The sysctl setting for rp_filter handles this for IPv4.
+#
+# == Authors
+#   Trevor Vaughan <tvaughan@onyxpoint.com>
+#
+class iptables::prevent_localhost_spoofing {
+  include '::iptables'
+
+  if $::ipv6_enabled {
+    iptables_rule{ 'prevent_ipv6_localhost_spoofing':
+      table    => 'raw',
+      comment  => 'Prevent Spoofing of Localhost Addresses',
+      first    => true,
+      header   => false,
+      apply_to => 'ipv6',
+      content  => '-A PREROUTING ! -i lo -s ::1 -j DROP'
+    }
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,6 +16,7 @@ describe 'iptables' do
           it { is_expected.to contain_service('iptables').with_ensure('running') }
           it { is_expected.to contain_service('iptables-retry').with_enable(true) }
           it { is_expected.to create_class('iptables::base_rules').with_allow_ping(true) }
+          it { is_expected.to create_class('iptables::prevent_localhost_spoofing') }
           it { is_expected.to create_iptables_optimize('/etc/sysconfig/iptables').with_disable(false) }
           it { is_expected.to create_file('/etc/init.d/iptables').with_ensure('file') }
           it { is_expected.to create_file('/etc/init.d/iptables-retry').with_ensure('file') }

--- a/spec/classes/prevent_localhost_spoofing.rb
+++ b/spec/classes/prevent_localhost_spoofing.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'iptables::prevent_localhost_spoofing' do
+  context  'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts) do
+        facts
+      end
+
+      context "on #{os}" do
+        context "default spoofing prevention" do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_iptables_rule('prevent_ipv6_localhost_spoofing').with_apply_to('ipv6') }
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,15 +81,6 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
   FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
 end
 
-Dir.chdir(File.join(fixture_path,'modules',module_name)) do
-  ['manifests','templates','lib'].each do |tgt|
-    if not File.symlink?(tgt) then
-      FileUtils.ln_sf("../../../../#{tgt}",tgt)
-    end
-  end
-end
-
-
 RSpec.configure do |c|
   # ENC-style environment facts
   c.default_facts = {


### PR DESCRIPTION
This patch ensures that IPv6 spoofed addresses will be rejected by
default.

Catalyst: https://access.redhat.com/articles/1305723

SIMP-45 #comment Full closure on the NTP issue