### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 ---
 fixtures:
   repositories:
-    common: "git://github.com/simp/pupmod-simp-common"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
   symlinks:
     iptables: "#{source_dir}"

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -1,4 +1,5 @@
 ---
 fixtures:
   symlinks:
+    simplib: "#{source_dir}/../simplib"
     iptables: "#{source_dir}"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,5 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-variables_not_enclosed-check
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,54 @@
 ---
 language: ruby
 cache: bundler
-fast_finish: true
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
+#  - 1.8.7  # bombs out on mime-types
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-script: bundle exec rake test
+script:
+    - 'bundle exec rake validate'
+    - 'bundle exec rake lint'
+    - 'bundle exec rake spec'
+# NOTE: `:environmentpath` was not supported before Puppet 3.5
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 4.1.0"
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: 1.8.7
     - rvm: 2.1.0
     - rvm: 2.2.1
-    - env:
-      - PUPPET_VERSION="~> 2.7.0"
-      - PUPPET_VERSION="~> 3.2.0"
-      - PUPPET_VERSION="~> 3.3.0"
-      - PUPPET_VERSION="~> 3.4.0"
-      - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 4.0.0"
-      - PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
 
   # Ruby 1.9.3
   - rvm: 1.9.3
@@ -67,46 +57,15 @@ matrix:
   # Ruby 2.0.0
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
 
   # Ruby 2.1.0
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.6.0"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 2.7.0"
-  # - No Ruby 2.2 for ~>3.X: https://tickets.puppetlabs.com/browse/PUP-3796
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'rake'
   gem 'puppet', puppetversion
   gem 'rspec', '< 3.2.0'
-  gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'rspec-puppet'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'simp-rspec-puppet-facts'

--- a/Rakefile
+++ b/Rakefile
@@ -1,50 +1,32 @@
-#!/usr/bin/rake -T
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet/version'
 require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
 require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
-
-
+# These gems aren't always present, for instance
+# on Travis with --without development
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'puppet_blacksmith/rake_tasks'
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
 end
 
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
 Rake::Task[:lint].clear
-
-# Lint Material
-begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-
-  PuppetLint.configuration.relative = true
-  PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
-  #PuppetLint.configuration.fail_on_warnings = true
-
-  # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
-  # http://puppet-lint.com/checks/class_parameter_defaults/
-  PuppetLint.configuration.send('disable_class_parameter_defaults')
-  # http://puppet-lint.com/checks/class_inherits_from_params_class/
-  PuppetLint.configuration.send('disable_class_inherits_from_params_class')
-
-  exclude_paths = [
-    "bundle/**/*",
-    "pkg/**/*",
-    "dist/**/*",
-    "vendor/**/*",
-    "spec/**/*",
-  ]
-  PuppetLint.configuration.ignore_paths = exclude_paths
-  PuppetSyntax.exclude_paths = exclude_paths
-rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
 end
 
 begin
@@ -56,6 +38,12 @@ rescue LoadError
   puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
+begin
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
+rescue LoadError
+  # Ignoring this for now since all of these are currently convenience methods.
+end
 
 desc "Run acceptance tests"
 RSpec::Core::RakeTask.new(:acceptance) do |t|

--- a/build/pupmod-iptables.spec
+++ b/build/pupmod-iptables.spec
@@ -1,15 +1,16 @@
 Summary: IPTables Puppet Module
 Name: pupmod-iptables
 Version: 4.1.0
-Release: 13
+Release: 14
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-auditd >= 2.0.0-0
 Requires: pupmod-common >= 4.0.0-0
+Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-rsyslog >= 2.0.0-0
-Requires: pupmod-concat >= 2.0.0-0
+Requires: pupmod-simpcat >= 2.0.0-0
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
@@ -17,7 +18,7 @@ Provides: pupmod-ip6tables
 Obsoletes: pupmod-ip6tables
 Obsoletes: pupmod-iptables-test
 
-Prefix: /etc/puppet/environments/simp/modules
+Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
 %description
 This Puppet module provides the capability to configure IPTables rules for your
@@ -71,6 +72,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-14
+- migration to simplib and simpcat (lib/ only)
+
 * Mon Jul 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-13
 - Added an iptables::prevent_localhost_spoofing class to handle IPv6 spoofed
   communication.

--- a/lib/puppet/provider/iptables_rule/manage.rb
+++ b/lib/puppet/provider/iptables_rule/manage.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:iptables_rule).provide(:manage) do
   }
 
   def initialize(*args)
-    require 'puppetx/simp/common'
+    require 'puppetx/simp/simplib'
     require 'puppetx/simp/iptables'
 
     super(*args)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -238,8 +238,8 @@ class iptables (
     'RedHat','CentOS': {
       if $::operatingsystemmajrelease > '6' {
         service{ 'firewalld':
-          enable => false,
           ensure => 'stopped',
+          enable => false,
         } -> Service['iptables']
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "simp-simplib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 1.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-iptables`.
SIMP-604 #comment Updated `pupmod-simp-iptables`.