### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 .*.sw?
+.yardoc
 dist
 /pkg
 /spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
 /.rspec_system
 /.vagrant
 /.bundle
-/vendor
 /Gemfile.lock
+/vendor
 /junit
 /log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,5 +1,4 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
---no-variables_not_enclosed-check
 --no-class_inherits_from_params_class-check
 --no-80chars-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,27 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
+before_script:
+  - bundle
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
+script:
+  - bundle exec rake test
+notifications:
+  email: false
 rvm:
-#  - 1.8.7  # bombs out on mime-types
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
-# NOTE: `:environmentpath` was not supported before Puppet 3.5
 env:
   global:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
     - PUPPET_VERSION="~> 3.5.0"
     - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
@@ -28,7 +31,6 @@ env:
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
-
 matrix:
   fast_finish: true
   allow_failures:
@@ -39,33 +41,50 @@ matrix:
     - env: PUPPET_VERSION="~> 3.6.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
     - env: PUPPET_VERSION="~> 4.1.0"
     - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 
   # Ruby 2.1.0
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,38 +2,38 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem 'rake'
+  gem "rake"
   gem 'puppet', puppetversion
-  gem 'rspec', '< 3.2.0'
-  gem 'rspec-puppet'
-  gem 'puppetlabs_spec_helper'
-  gem 'metadata-json-lint'
-  gem 'simp-rspec-puppet-facts'
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
+
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
-  # FIXME: simp-rake-helpers should support Puppet 4.X
-  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
-      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
     gem 'simp-rake-helpers'
   end
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'vagrant-wrapper'
-  gem 'puppet-blacksmith'
-  gem 'guard'
-  gem 'guard-rake'
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'
 end
@@ -41,4 +41,12 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/build/pupmod-iptables.spec
+++ b/build/pupmod-iptables.spec
@@ -1,7 +1,7 @@
 Summary: IPTables Puppet Module
 Name: pupmod-iptables
 Version: 4.1.0
-Release: 14
+Release: 15
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -72,6 +72,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Tue Jan 26 2016 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-15
+- Normalized common static module assets
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-14
 - migration to simplib and simpcat (lib/ only)
 

--- a/manifests/add_all_listen.pp
+++ b/manifests/add_all_listen.pp
@@ -67,13 +67,13 @@ define iptables::add_all_listen (
 #     Set the string to 'any' to allow all networks
     $client_nets = '127.0.0.1')
 {
-  iptables_rule { "all_$name":
+  validate_net_list($client_nets,'^(any|ALL)$')
+
+  iptables_rule { "all_${name}":
     first    => $first,
     absolute => $absolute,
     order    => $order,
     apply_to => $apply_to,
     content  => template('iptables/allow_all_services.erb')
   }
-
-  validate_net_list($client_nets,'^(any|ALL)$')
 }

--- a/manifests/add_icmp_listen.pp
+++ b/manifests/add_icmp_listen.pp
@@ -74,6 +74,7 @@ define iptables::add_icmp_listen (
 #     'any' to allow all networks
   $client_nets = '127.0.0.1'
 ) {
+  validate_net_list($client_nets,'^(any|ALL)$')
 
   iptables_rule { "icmp_${name}":
     first    => $first,
@@ -82,6 +83,4 @@ define iptables::add_icmp_listen (
     apply_to => $apply_to,
     content  => template('iptables/allow_icmp_services.erb')
   }
-
-  validate_net_list($client_nets,'^(any|ALL)$')
 }

--- a/manifests/add_tcp_stateful_listen.pp
+++ b/manifests/add_tcp_stateful_listen.pp
@@ -74,6 +74,8 @@ define iptables::add_tcp_stateful_listen (
 #     'any' to allow all networks
   $client_nets = '127.0.0.1'
 ) {
+#  validate_net_list($client_nets,'^(any|ALL)$')
+
   $l_protocol = 'tcp'
 
   iptables_rule { "tcp_${name}":
@@ -83,6 +85,4 @@ define iptables::add_tcp_stateful_listen (
     apply_to => $apply_to,
     content  => template('iptables/allow_tcp_udp_services.erb')
   }
-
-#  validate_net_list($client_nets,'^(any|ALL)$')
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -227,7 +227,7 @@ class iptables (
         }
       }
       default: {
-        fail("$::operatingsystem is not yet supported by $module_name")
+        fail("${::operatingsystem} is not yet supported by ${module_name}")
       }
     }
   }
@@ -244,7 +244,7 @@ class iptables (
       }
     }
     default: {
-      fail("$::operatingsystem is not yet supported by $module_name")
+      fail("${::operatingsystem} is not yet supported by ${module_name}")
     }
   }
 

--- a/manifests/scanblock.pp
+++ b/manifests/scanblock.pp
@@ -119,6 +119,13 @@ class iptables::scanblock (
   $ip_list_uid = hiera('iptables::xt_recent::ip_list_uid','0'),
   $ip_list_gid = hiera('iptables::xt_recent::ip_list_gid','0')
 ) {
+  validate_bool($enable)
+  validate_bool($set_rttl)
+  validate_integer($update_interval)
+  validate_integer($logs_per_minute)
+  validate_integer($seconds)
+  validate_integer($hitcount)
+
   include 'iptables'
 
   if str2bool($set_rttl) {
@@ -151,11 +158,4 @@ class iptables::scanblock (
     ip_list_gid       => $ip_list_gid,
     notify_iptables   => true
   }
-
-  validate_bool($enable)
-  validate_bool($set_rttl)
-  validate_integer($update_interval)
-  validate_integer($logs_per_minute)
-  validate_integer($seconds)
-  validate_integer($hitcount)
 }

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -9,3 +9,4 @@ HOSTS:
     hypervisor : vagrant
 CONFIG:
   type: foss
+  vagrant_memsize: 256

--- a/spec/acceptance/nodesets/centos-70-x64.yml
+++ b/spec/acceptance/nodesets/centos-70-x64.yml
@@ -9,3 +9,4 @@ HOSTS:
     hypervisor : vagrant
 CONFIG:
   type: foss
+  vagrant_memsize: 256

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,3 +9,4 @@ HOSTS:
     hypervisor : vagrant
 CONFIG:
   type: foss
+  vagrant_memsize: 256

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,4 +1,8 @@
 require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
 
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
@@ -11,48 +15,36 @@ unless ENV['BEAKER_provision'] == 'no'
   end
 end
 
-# returns an Array of puppet modules declared in .fixtures.yml
-def pupmods_in_fixtures_yaml
-  require 'yaml'
-  fixtures_yml = File.expand_path( '../.fixtures.yml', File.dirname(__FILE__))
-  data         = YAML.load_file( fixtures_yml )
-  repos        = data.fetch('fixtures').fetch('repositories').keys
-  symlinks     = data.fetch('fixtures').fetch('symlinks', {}).keys
-  (repos + symlinks)
-end
-
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  # ensure that environment OS is ready on each host
+  fix_errata_on hosts
 
   # Readable test descriptions
   c.formatter = :documentation
 
+  c.before :context do
+      # Install modules and dependencies from spec/fixtures/modules
+      copy_fixture_modules_to( hosts )
+      pluginsync_on( hosts )
+      hosts.each do |host|
+        on(host,'yum clean all')
+      end
+  end
+
   # Configure all nodes in nodeset
   c.before :suite do
-    # net-tools required for netstat utility being used by be_listening
-    if fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7'
-      pp = <<-EOS
-        package { 'net-tools': ensure => installed }
-      EOS
-
-      apply_manifest_on(agents, pp, :catch_failures => false)
-    end
-
-    # Install module and dependencies
-    puppet_module_install(:source => proj_root, :module_name => 'iptables')
-
-    hosts.each do |host|
-      # allow spec_prep to provide modules (to support isolated networks)
-      if ENV['BEAKER_use_fixtures_dir_for_modules'] == 'yes'
-        pupmods_in_fixtures_yaml.each do |pupmod|
-          mod_root = File.expand_path( "fixtures/modules/#{pupmod}", File.dirname(__FILE__))
-          puppet_module_install(:source => mod_root, :module_name => pupmod)
-        end
+    begin
+      # Generate and install PKI certificates on each SUT
+      Dir.mktmpdir do |cert_dir|
+        run_fake_pki_ca_on( default, hosts, cert_dir )
+        hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
+      end
+    rescue StandardError, ScriptError => e
+      if ENV['PRY']
+        require 'pry'; binding.pry
       else
-        # TODO: update when the relevant SIMP modules are on the forge
-        on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+        raise e
       end
     end
   end


### PR DESCRIPTION
This commit synchronizes all common static module assets with current SIMP
module standards.

Also:
- created metadata.json, .puppet-lint.rc, .travis.yml, .gitignore
- moved validations to the top of each class
- bumped RPM to 4.1.0-15

SIMP-667 #comment updated `pupmod-simp-iptables`
SIMP-734 #close #comment normalized common module assets