### PR TITLE
(SIMP-1000) Remove custom type warning in pupmod-simp-iptables

### DIFF
--- a/build/pupmod-iptables.spec
+++ b/build/pupmod-iptables.spec
@@ -1,7 +1,7 @@
 Summary: IPTables Puppet Module
 Name: pupmod-iptables
 Version: 4.1.0
-Release: 15
+Release: 17
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -73,6 +73,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Tue Apr 12 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 4.1.0-17
+- Removed custom type deprecation warning
+
 * Fri Feb 19 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 4.1.0-16
 - Added compliance function support
 

--- a/lib/puppet/type/iptables_rule.rb
+++ b/lib/puppet/type/iptables_rule.rb
@@ -1,141 +1,139 @@
-module Puppet
-  newtype(:iptables_rule) do
-    @doc = "Authoritatively manage iptables rules.  This type is
-            atomic, either all rules work, or the old rules are
-            preserved."
+Puppet::Type.newtype(:iptables_rule) do
+  @doc = "Authoritatively manage iptables rules.  This type is
+          atomic, either all rules work, or the old rules are
+          preserved."
 
-    def initialize(args)
-      super
+  def initialize(args)
+    super
 
-      self[:tag] = ['iptables','ip6tables']
+    self[:tag] = ['iptables','ip6tables']
+  end
+
+  newparam(:name) do
+    isnamevar
+    desc "The name of the rule. Simply used for creating the unique fragments."
+  end
+
+  newparam(:comment) do
+    desc "A comment to add to the rule."
+    defaultto ""
+
+    munge do |value|
+      # IPTables can only take comments up to 256 characters.
+      value[0..255]
     end
+  end
 
-    newparam(:name) do
-      isnamevar
-      desc "The name of the rule. Simply used for creating the unique fragments."
+  newparam(:header) do
+    desc "Whether or not to auto-include the table LOCAL-INPUT in
+          the rule."
+    newvalues(:true,:false)
+    defaultto 'true'
+
+    munge do |value|
+      value.to_s
     end
+  end
 
-    newparam(:comment) do
-      desc "A comment to add to the rule."
-      defaultto ""
+  newparam(:apply_to) do
+    desc "What version(s) of iptables to which to apply this rule.
+          If set to 'auto' (the default) then we'll try to guess
+          what you want and default to ['ipv4','ipv6'].
 
-      munge do |value|
-        # IPTables can only take comments up to 256 characters.
-        value[0..255]
+          If 'auto' is set then each line will be evaluated as an
+          independent rule.
+          - Any rules that have IPv4 addresses will be applied to
+            iptables.
+          - Any rules that have IPv6 addresses will be applied to
+            ip6tables.
+          - All other rules will be applied to *both* utilities.
+          - If in doubt, split your rules and specify your tables!"
+    newvalues(:ipv4,:ipv6,:all,:auto)
+    defaultto 'auto'
+
+    munge do |value|
+      if value == 'all' then
+        value = ['ipv4','ipv6']
       end
+      value
     end
+  end
 
-    newparam(:header) do
-      desc "Whether or not to auto-include the table LOCAL-INPUT in
-            the rule."
-      newvalues(:true,:false)
-      defaultto 'true'
+  newparam(:table) do
+    desc "The name of the table that you are adding to."
+    defaultto :filter
+  end
 
-      munge do |value|
-        value.to_s
+  newparam(:first) do
+    desc "Set to 'true' if you want to prepend your rule."
+    newvalues(:true,:false)
+    defaultto :false
+  end
+
+  newparam(:absolute) do
+    desc "Set to 'true' if you want the rule to be the absolute
+          first or last. This is relative and places items in
+          alphabetical order if multiple absolute first/lasts are
+          specified."
+    newvalues(:true,:false)
+    defaultto :false
+  end
+
+  newparam(:order) do
+    desc "The order in which the rule should appear. 1 is the
+          minimum and 999 is the max."
+    newvalues(/\d+/)
+    defaultto '11'
+
+    munge do |value|
+      if resource[:first].to_s == 'true' then
+        debug("Setting :order to 1 due to 'first'")
+        value = '1'
+      elsif value.to_i < 1 then
+        debug("Setting :order to 1")
+        value = '1'
+      elsif value.to_i > 999 then
+        debug("Setting :order to 999")
+        value = '999'
       end
-    end
 
-    newparam(:apply_to) do
-      desc "What version(s) of iptables to which to apply this rule.
-            If set to 'auto' (the default) then we'll try to guess
-            what you want and default to ['ipv4','ipv6'].
-
-            If 'auto' is set then each line will be evaluated as an
-            independent rule.
-            - Any rules that have IPv4 addresses will be applied to
-              iptables.
-            - Any rules that have IPv6 addresses will be applied to
-              ip6tables.
-            - All other rules will be applied to *both* utilities.
-            - If in doubt, split your rules and specify your tables!"
-      newvalues(:ipv4,:ipv6,:all,:auto)
-      defaultto 'auto'
-
-      munge do |value|
-        if value == 'all' then
-          value = ['ipv4','ipv6']
-        end
-        value
-      end
-    end
-
-    newparam(:table) do
-      desc "The name of the table that you are adding to."
-      defaultto :filter
-    end
-
-    newparam(:first) do
-      desc "Set to 'true' if you want to prepend your rule."
-      newvalues(:true,:false)
-      defaultto :false
-    end
-
-    newparam(:absolute) do
-      desc "Set to 'true' if you want the rule to be the absolute
-            first or last. This is relative and places items in
-            alphabetical order if multiple absolute first/lasts are
-            specified."
-      newvalues(:true,:false)
-      defaultto :false
-    end
-
-    newparam(:order) do
-      desc "The order in which the rule should appear. 1 is the
-            minimum and 999 is the max."
-      newvalues(/\d+/)
-      defaultto '11'
-
-      munge do |value|
+      if resource[:absolute].to_s == 'true' then
         if resource[:first].to_s == 'true' then
-          debug("Setting :order to 1 due to 'first'")
-          value = '1'
-        elsif value.to_i < 1 then
-          debug("Setting :order to 1")
-          value = '1'
-        elsif value.to_i > 999 then
-          debug("Setting :order to 999")
+          debug("Setting :order to absolute first")
+          value = '0'
+        else
+          debug("Setting :order to absolute last")
           value = '999'
         end
-
-        if resource[:absolute].to_s == 'true' then
-          if resource[:first].to_s == 'true' then
-            debug("Setting :order to absolute first")
-            value = '0'
-          else
-            debug("Setting :order to absolute last")
-            value = '999'
-          end
-        end
-        value
       end
+      value
     end
+  end
 
-    newparam(:resolve) do
-      desc "Whether or not to use DNS resolution to identify hostnames
-            in IPTables statements.
+  newparam(:resolve) do
+    desc "Whether or not to use DNS resolution to identify hostnames
+          in IPTables statements.
 
-            This should probably be left at :true since it is a rare
-            scenario and, should you use this, you will want the rule
-            to go into either iptables or ip6tables correctly.
+          This should probably be left at :true since it is a rare
+          scenario and, should you use this, you will want the rule
+          to go into either iptables or ip6tables correctly.
 
-            With this enabled, the IP address that is resolved will be
-            added to IPTables and not the hostname itself."
+          With this enabled, the IP address that is resolved will be
+          added to IPTables and not the hostname itself."
 
-      newvalues(:true,:false)
-      defaultto :true
-    end
+    newvalues(:true,:false)
+    defaultto :true
+  end
 
-    newproperty(:content) do
-      desc "The content of the rule that should be added"
-      newvalues(/\w+/)
+  newproperty(:content) do
+    desc "The content of the rule that should be added"
+    newvalues(/\w+/)
 
-      def change_to_s(current_value, new_value)
-        if current_value and current_value.is_a?(Array) and not current_value.empty? then
-          return "#{current_value.join(' and ')} rules changed."
-        else
-          super
-        end
+    def change_to_s(current_value, new_value)
+      if current_value and current_value.is_a?(Array) and not current_value.empty? then
+        return "#{current_value.join(' and ')} rules changed."
+      else
+        super
       end
     end
   end


### PR DESCRIPTION
Removed the custoom type deprecation warning in iptables_rule

SIMP-995 #comment Fixes the pupmod-simp-iptables part of this story
SIMP-995 #close
SIMP-1000 #close
