### PR TITLE
(SIMP-1002) Change default provider for iptables services

### DIFF
--- a/build/pupmod-iptables.spec
+++ b/build/pupmod-iptables.spec
@@ -1,7 +1,7 @@
 Summary: IPTables Puppet Module
 Name: pupmod-iptables
 Version: 4.1.0
-Release: 15
+Release: 17
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -73,6 +73,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Apr 13 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 4.1.0-17
+- Changed default provider of services to redhat
+
 * Fri Feb 19 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 4.1.0-16
 - Added compliance function support
 
@@ -150,11 +153,6 @@ fi
 - Made several changes to the iptables_rule custom type to:
   * Now resolves all hostnames in the rules by default. This can be
     disabled but may cause issues with the autodiscovery between ipv4
-    and ipv6 rules.
-  * Handle blank lines
-  * Account for all table declarations
-  * Compare while ignoring the table declarations since those are
-    allowed to vary.
   * Ensure that the -A header is not prepended to a rule if it already
     has a header value.
   * Ensure that no rules attempt to be added if they belong to a table

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,15 +144,17 @@ class iptables (
     require    => [
       File['/etc/init.d/iptables'],
       Package['iptables']
-    ]
+    ],
+    provider   => 'redhat'
   }
 
   service { 'iptables-retry':
-    enable  => true,
-    require => [
+    enable   => true,
+    require  => [
       File['/etc/init.d/iptables-retry'],
       Package['iptables']
-    ]
+    ],
+    provider => 'redhat'
   }
 
   if $::ipv6_enabled {
@@ -193,12 +195,14 @@ class iptables (
       restart    => '/sbin/ip6tables-restore /etc/sysconfig/ip6tables || ( /sbin/ip6tables-restore /etc/sysconfig/ip6tables.bak && exit 3 )',
       hasstatus  => true,
       require    => File['/etc/init.d/ip6tables'],
-      subscribe  => Ip6tables_optimize['/etc/sysconfig/ip6tables']
+      subscribe  => Ip6tables_optimize['/etc/sysconfig/ip6tables'],
+      provider   => 'redhat'
     }
 
     service { 'ip6tables-retry':
-      enable  => true,
-      require => File['/etc/init.d/ip6tables-retry']
+      enable   => true,
+      require  => File['/etc/init.d/ip6tables-retry'],
+      provider => 'redhat'
     }
 
     # A rule optimizer (required)


### PR DESCRIPTION
Changed default provider for iptables services to redhat because Puppet could
not enable them

SIMP-1001 #comment Fixes the pupmod-simp-iptables part of this story
SIMP-1002 #close