### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,7 +1,9 @@
-Requires: pupmod-simp-auditd >= 2.0.0-0
-Requires: pupmod-simp-compliance_markup
-Requires: pupmod-simp-rsyslog >= 2.0.0-0
-Requires: pupmod-simp-simpcat >= 2.0.0-0
-Provides: pupmod-simp-ip6tables
 Obsoletes: pupmod-ip6tables >= 0.0.1
 Obsoletes: pupmod-iptables-test >= 0.0.1
+Provides: pupmod-simp-ip6tables
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "author": "simp",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",
@@ -15,27 +15,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0"
-    },
-    {
-      "name": "simp/auditd",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.0.0"
-    },
-    {
-      "name": "simp/rsyslog",
-      "version_requirement": ">= 2.0.0"
-    },
-    {
-      "name": "simp/simpcat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-iptables`
SIMP-1606 #close