### PR TITLE
(SIMP-1677) Remove deprecated Puppet.newtype

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Wed Nov 09 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.6-0
+- Fixed bug in the set provider for the xt_recent type that required manual
+  modifications to the permissions for the /sys/module/xt_recent/parameters/*
+  files, in order for the scanblock capability to be enabled.
+- Fixed bugs in the xt_recent type and its set provider that caused
+  Puppet to believe /sys/module/xt_recent/parameters/ip_list_perms
+  file content had changed when it had not.
+- Eliminated use of deprecated Puppet.newtype
+- Updated to compliance_markup version 2
+
 * Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.5-0
 - Updated the ip6tables_optimize provider so that it works in Puppet 4
 

--- a/lib/puppet/type/xt_recent.rb
+++ b/lib/puppet/type/xt_recent.rb
@@ -1,88 +1,80 @@
-module Puppet
-  newtype(:xt_recent) do
-    @doc =<<-EOM
-      Sets the various options on the running xt_recent kernel module.
+Puppet::Type.newtype(:xt_recent) do
+  @doc =<<-EOM
+    Sets the various options on the running xt_recent kernel module.
 
-      If the module needs to be loaded, attempts to load the module.
+    If the module needs to be loaded, attempts to load the module.
+  EOM
+
+  newparam(:name) do
+    isnamevar
+    desc "The path to the xt_recent variables to be manipulated"
+
+    validate do |value|
+      require 'pathname'
+
+      if not Pathname.new(value).absolute? then
+        fail Puppet::Error, "'name' must be an absolute path, got: '#{value}'"
+      end
+    end
+  end
+
+  newproperty(:ip_list_tot) do
+    desc <<-EOM
+      The number of addresses remembered per table. This effectively
+      becomes the maximum size of your block list. Be aware that
+      more addresses means more load on your system.
     EOM
 
-    newparam(:name) do
-      isnamevar
-      desc "The path to the xt_recent variables to be manipulated"
+    newvalues(/^\d+$/)
+    defaultto '100'
+  end
 
-      validate do |value|
-        require 'pathname'
+  newproperty(:ip_pkt_list_tot) do
+    desc <<-EOM
+      The number of packets per address remembered.
+    EOM
 
-        if not Pathname.new(value).absolute? then
-          fail Puppet::Error, "'name' must be an absolute path, got: '#{value}'"
-        end
-      end
-    end
+    newvalues(/^\d+$/)
+    defaultto '20'
+  end
 
-    newproperty(:ip_list_tot) do
-      desc <<-EOM
-        The number of addresses remembered per table. This effectively
-        becomes the maximum size of your block list. Be aware that
-        more addresses means more load on your system.
-      EOM
+  newproperty(:ip_list_hash_size) do
+    desc <<-EOM
+      Hash table size. 0 means to calculate it based on ip_list_tot.
+    EOM
 
-      newvalues(/^\d+$/)
-      defaultto '100'
-    end
+    newvalues(/^\d+$/)
+    defaultto '0'
+  end
 
-    newproperty(:ip_pkt_list_tot) do
-      desc <<-EOM
-        The number of packets per address remembered.
-      EOM
+  newproperty(:ip_list_perms) do
+    desc <<-EOM
+      Permissions for /proc/net/xt_recent/* files.
+    EOM
 
-      newvalues(/^\d+$/)
-      defaultto '20'
-    end
+    newvalues(/^[0-7]{4}$/)
+    defaultto '0640'
+  end
 
-    newproperty(:ip_list_hash_size) do
-      desc <<-EOM
-        Hash table size. 0 means to calculate it based on ip_list_tot,
-        default: 512.
-      EOM
+  newproperty(:ip_list_uid) do
+    desc <<-EOM
+      Numerical UID for ownership of /proc/net/xt_recent/* files.
+    EOM
 
-      newvalues(/^\d+$/)
-      defaultto '0'
-    end
+    newvalues(/^\d+$/)
+    defaultto '0'
+  end
 
-    newproperty(:ip_list_perms) do
-      desc <<-EOM
-        Permissions for /proc/net/xt_recent/* files.
-      EOM
+  newproperty(:ip_list_gid) do
+    desc <<-EOM
+      Numerical GID for ownership of /proc/net/xt_recent/* files.
+    EOM
 
-      newvalues(/^[0-7]{4}$/)
-      defaultto '0640'
+    newvalues(/^\d+$/)
+    defaultto '0'
+  end
 
-      # The value on the system is held in decimal.
-      munge do |value|
-        value.to_i(8).to_s(10)
-      end
-    end
-
-    newproperty(:ip_list_uid) do
-      desc <<-EOM
-        Numerical UID for ownership of /proc/net/xt_recent/* files.
-      EOM
-
-      newvalues(/^\d+$/)
-      defaultto '0'
-    end
-
-    newproperty(:ip_list_gid) do
-      desc <<-EOM
-        Numerical GID for ownership of /proc/net/xt_recent/* files.
-      EOM
-
-      newvalues(/^\d+$/)
-      defaultto '0'
-    end
-
-    autorequire(:file) do
-      [ '/etc/modprobe.d/xt_recent.conf' ]
-    end
+  autorequire(:file) do
+    [ '/etc/modprobe.d/xt_recent.conf' ]
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,8 +92,6 @@ class iptables (
   validate_bool($prevent_localhost_spoofing)
   validate_bool($disable)
 
-  compliance_map()
-
   if $enable_default_rules { include '::iptables::base_rules' }
   if $enable_scanblock { include '::iptables::scanblock' }
   if $prevent_localhost_spoofing { include '::iptables::prevent_localhost_spoofing' }

--- a/manifests/scanblock.pp
+++ b/manifests/scanblock.pp
@@ -84,8 +84,7 @@
 # [*ip_list_hash_size*]
 #   Integer:
 #   Default: 0
-#     Hash table size. 0 means to calculate it based on ip_list_tot,
-#     default: 512.
+#     Hash table size. 0 means to calculate it based on ip_list_tot.
 #
 # [*ip_list_perms*]
 #   Integer:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "author": "simp",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.1 < 2.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/add_tcp_stateful_listen_spec.rb
+++ b/spec/acceptance/add_tcp_stateful_listen_spec.rb
@@ -2,58 +2,61 @@ require 'spec_helper_acceptance'
 
 test_name "iptables::add_tcp_stateful_listen"
 
-describe 'iptables' do
-  let(:manifest) {
-    <<-EOS
-      class { 'iptables': }
+['6', '7'].each do |os_major_version|
+  describe "iptables::add_tcp_stateful_listen for CentOS #{os_major_version}" do
+    let(:host) {only_host_with_role( hosts, "server#{os_major_version}" ) }
+    let(:manifest) {
+      <<-EOS
+        class { 'iptables': }
 
-      # Ironically, if iptables applies correctly, its default settings will
-      # deny Vagrant access via SSH.  So, it is neccessary for beaker to also
-      # define a rule that permit SSH access from the standard Vagrant subnets:
-      iptables::add_tcp_stateful_listen { 'allow_sshd':
-        client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
-        dports      => '22',
-      }
+        # Ironically, if iptables applies correctly, its default settings will
+        # deny Vagrant access via SSH.  So, it is neccessary for beaker to also
+        # define a rule that permit SSH access from the standard Vagrant subnets:
+        iptables::add_tcp_stateful_listen { 'allow_sshd':
+          client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
+          dports      => '22',
+        }
 
 
-      iptables::add_tcp_stateful_listen { 'test_tcp_on_both':
-        client_nets => ['10.0.2.0/16', 'fe80::/64'],  # Standard Beaker/Vagrant subnet
-        dports      => '2222',
-        apply_to    => 'all',
-      }
+        iptables::add_tcp_stateful_listen { 'test_tcp_on_both':
+          client_nets => ['10.0.2.0/16', 'fe80::/64'],  # Standard Beaker/Vagrant subnet
+          dports      => '2222',
+          apply_to    => 'all',
+        }
 
-      iptables::add_tcp_stateful_listen { 'test_tcp_on_ipv4':
-        client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
-        dports      => '4444',
-        apply_to    => 'ipv4',
-      }
+        iptables::add_tcp_stateful_listen { 'test_tcp_on_ipv4':
+          client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
+          dports      => '4444',
+          apply_to    => 'ipv4',
+        }
 
-      iptables::add_tcp_stateful_listen { 'test_tcp_on_ipv6':
-        client_nets => ['fe80::/64'],  # Standard Beaker/Vagrant subnet
-        dports      => '6666',
-        apply_to    => 'ipv6',
-      }
-    EOS
-  }
+        iptables::add_tcp_stateful_listen { 'test_tcp_on_ipv6':
+          client_nets => ['fe80::/64'],  # Standard Beaker/Vagrant subnet
+          dports      => '6666',
+          apply_to    => 'ipv6',
+        }
+      EOS
+    }
 
-  it 'should work without errors' do
-    apply_manifest(manifest, :catch_failures => true)
-  end
+    it 'should work without errors' do
+      apply_manifest_on(host, manifest, :catch_failures => true)
+    end
 
-  it 'should allow port 2222 for IPv4' do
-    shell("iptables-save   | grep ' -p tcp' | grep -w 2222", :acceptable_exit_codes => 0)
-  end
+    it 'should allow port 2222 for IPv4' do
+      on(host, "iptables-save   | grep ' -p tcp' | grep -w 2222", :acceptable_exit_codes => 0)
+    end
 
-  it 'should allow port 2222 for IPv6' do
-    shell("ip6tables-save  | grep ' -p tcp' | grep -w 2222", :acceptable_exit_codes => 0)
-  end
+    it 'should allow port 2222 for IPv6' do
+      on(host, "ip6tables-save  | grep ' -p tcp' | grep -w 2222", :acceptable_exit_codes => 0)
+    end
 
-  it 'should allow port 4444 for IPv4' do
-    shell("iptables-save   | grep ' -p tcp' | grep -w 4444", :acceptable_exit_codes => 0)
-  end
+    it 'should allow port 4444 for IPv4' do
+      on(host, "iptables-save   | grep ' -p tcp' | grep -w 4444", :acceptable_exit_codes => 0)
+    end
 
-  it 'should allow port 6666 for IPv6' do
-    shell("ip6tables-save  | grep ' -p tcp' | grep -w 6666", :acceptable_exit_codes => 0)
+    it 'should allow port 6666 for IPv6' do
+      on(host, "ip6tables-save  | grep ' -p tcp' | grep -w 6666", :acceptable_exit_codes => 0)
+    end
   end
 end
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -2,42 +2,177 @@ require 'spec_helper_acceptance'
 
 test_name "iptables class"
 
-describe 'iptables' do
-  let(:manifest) {
-    <<-EOS
-      class { 'iptables': }
+['6', '7'].each do |os_major_version|
+  describe "iptables class for CentOS #{os_major_version}" do
+    let(:host) {only_host_with_role( hosts, "server#{os_major_version}" ) }
 
-      # Ironically, if iptables applies correctly, its default settings will
-      # deny Vagrant access via SSH.  So, it is neccessary for beaker to also
-      # define a rule that permit SSH access from the standard Vagrant subnets:
-      iptables::add_tcp_stateful_listen { 'allow_sshd':
-        client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
-        dports      => '22',
+    context 'default parameters' do
+      let(:manifest) {
+      <<-EOS
+        class { 'iptables': }
+
+        # Ironically, if iptables applies correctly, its default settings will
+        # deny Vagrant access via SSH.  So, it is neccessary for beaker to also
+        # define a rule that permit SSH access from the standard Vagrant subnets:
+        iptables::add_tcp_stateful_listen { 'allow_sshd':
+          client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
+          dports      => '22',
+        }
+      EOS
       }
-    EOS
-  }
 
-  it 'should work with no errors' do
-    apply_manifest(manifest, :catch_failures => true)
-  end
+      it 'should work with no errors' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
 
-  it 'should be idempotent' do
-    apply_manifest(manifest, :catch_changes => true)
-  end
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, :catch_changes => true)
+      end
 
-  it 'should install the iptables package' do
-    expect(shell("puppet resource package iptables").stdout).to_not include('absent')
-  end
+      it 'should install the iptables package' do
+        expect(on(host, "puppet resource package iptables").stdout).to_not include('absent')
+      end
 
-  it 'should ensure that the iptables service is running' do
-    expect(shell("puppet resource service iptables").stdout).to include('running')
-  end
+      it 'should ensure that the iptables service is running' do
+        expect(on(host, "puppet resource service iptables").stdout).to include('running')
+      end
 
-  it 'should include a single TCP rule' do
-    shell("test `iptables-save  | grep ' -p tcp' | wc -l` -eq 1", :acceptable_exit_codes => 0)
-  end
+      it 'should include a single TCP rule' do
+        on(host, "test `iptables-save  | grep ' -p tcp' | wc -l` -eq 1", :acceptable_exit_codes => 0)
+      end
 
-  it 'should allow port 22' do
-    expect(shell("iptables-save  | grep ' -p tcp'").stdout).to include(' --dport', ' 22')
+      it 'should allow port 22' do
+        expect(on(host, "iptables-save  | grep ' -p tcp'").stdout).to include(' --dport', ' 22')
+      end
+    end
+
+    context 'with scanblock enabled' do
+      let(:manifest_with_scanblock_enabled) {
+      <<-EOS
+        class { 'iptables': enable_scanblock => true}
+
+        # Ironically, if iptables applies correctly, its default settings will
+        # deny Vagrant access via SSH.  So, it is neccessary for beaker to also
+        # define a rule that permit SSH access from the standard Vagrant subnets:
+        iptables::add_tcp_stateful_listen { 'allow_sshd':
+          client_nets => ['10.0.2.0/16'],  # Standard Beaker/Vagrant subnet
+          dports      => '22',
+        }
+      EOS
+      }
+
+     let(:hieradata_with_overrides) {
+<<-EOM
+---
+iptables::xt_recent::ip_list_tot : '400'
+iptables::xt_recent::ip_pkt_list_tot : '40'
+iptables::xt_recent::ip_list_hash_size : '256'
+iptables::xt_recent::ip_list_perms : '0644'
+EOM
+      }
+
+      it 'should work with no errors' do
+        apply_manifest_on(host, manifest_with_scanblock_enabled, :catch_failures => true)
+      end
+
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest_with_scanblock_enabled, :catch_changes => true)
+      end
+
+      it 'should install and configure xt_recent kernel module using defaults' do
+        on(host, "lsmod  | grep xt_recent", :acceptable_exit_codes => 0)
+
+        on(host, "cat /etc/modprobe.d/xt_recent.conf", :acceptable_exit_codes => 0) do
+          expected = "options xt_recent ip_list_tot=200 ip_pkt_list_tot=20 ip_list_hash_size=0" +
+            " ip_list_perms=0640 ip_list_uid=0 ip_list_gid=0"
+          expect(stdout).to eq(expected)
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_tot", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("200\n")
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_pkt_list_tot", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("20\n")
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_hash_size", :acceptable_exit_codes => 0) do
+          expect(stdout).to match(/[1-9]+[0-9]/)  # computed value
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_perms", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("416\n")
+        end
+ 
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_uid", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("0\n")
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_gid", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("0\n")
+        end
+      end
+
+      it 'should add electric fence rules to iptables and ip6tables' do
+        on(host, 'iptables-save',  :acceptable_exit_codes => 0) do
+          expect(stdout).to match(/-A LOCAL-INPUT -m recent --update --seconds 3600 --name BANNED .*--rsource -j DROP/m)
+          expect(stdout).to match(/-A LOCAL-INPUT -m state --state NEW -j ATTK_CHECK/m)
+          expect(stdout).to match(/-A ATTACKED -m limit --limit 5\/min -j LOG --log-prefix \"IPT: \(Rule ATTACKED\): \"/m)
+          expect(stdout).to match(/-A ATTACKED -m recent --set --name BANNED .*--rsource -j DROP/m)
+          expect(stdout).to match(/-A ATTK_CHECK -m recent --set --name ATTK .*--rsource/m)
+          expect(stdout).to match(/-A ATTK_CHECK -m recent --update --seconds 60 --hitcount 2 --name ATTK .*--rsource -j ATTACKED/m)
+        end
+
+        on(host, 'ip6tables-save',  :acceptable_exit_codes => 0) do
+          expect(stdout).to match(/-A LOCAL-INPUT -m state --state NEW -j ATTK_CHECK/m)
+          expect(stdout).to match(/-A ATTACKED -m limit --limit 5\/min -j LOG --log-prefix \"IPT: \(Rule ATTACKED\): \"/m)
+          expect(stdout).to match(/-A ATTACKED -m recent --set --name BANNED .*--rsource -j DROP/m)
+          expect(stdout).to match(/-A ATTK_CHECK -m recent --set --name ATTK .*--rsource/m)
+
+          #FIXME Why are these ipv6 iptables rules missing for CentOS6?
+          unless os_major_version == '6'
+            expect(stdout).to match(/-A LOCAL-INPUT -m recent --update --seconds 3600 --name BANNED .*--rsource -j DROP/m)
+            expect(stdout).to match(/-A ATTK_CHECK -m recent --update --seconds 60 --hitcount 2 --name ATTK .*--rsource -j ATTACKED/m)
+          end
+        end
+      end
+
+      it 'should configure xt_recent kernel module using hieradata overrides' do
+        set_hieradata_on(host, hieradata_with_overrides)
+        apply_manifest_on(host, manifest_with_scanblock_enabled, :catch_failures => true)
+
+        on(host, "cat /etc/modprobe.d/xt_recent.conf", :acceptable_exit_codes => 0) do
+          expected = "options xt_recent ip_list_tot=400 ip_pkt_list_tot=40 ip_list_hash_size=256" +
+            " ip_list_perms=0644 ip_list_uid=0 ip_list_gid=0"
+          expect(stdout).to eq(expected)
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_tot", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("400\n")
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_pkt_list_tot", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("40\n")
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_hash_size", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("256\n")
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_perms", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("420\n")
+        end
+ 
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_uid", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("0\n")
+        end
+
+        on(host, "cat /sys/module/xt_recent/parameters/ip_list_gid", :acceptable_exit_codes => 0) do
+          expect(stdout).to eq("0\n")
+        end
+      end
+
+      #TODO verify iptable electric fence rules do what is expected!
+    end
   end
 end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,11 +1,16 @@
 HOSTS:
-  default:
+  server7:
     roles:
-      - agent
+      - server7
       - default
     platform: el-7-x86_64
-    box :     centos-70-x64-nocm
-    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/centos-7.0-64-nocm/versions/1.0.1/providers/virtualbox.box
+    box :     centos/7
+    hypervisor : vagrant
+  server6:
+    roles:
+      - server6
+    platform: el-6-x86_64
+    box :     centos/6
     hypervisor : vagrant
 CONFIG:
   type: foss

--- a/spec/defines/add_udp_listen_spec.rb
+++ b/spec/defines/add_udp_listen_spec.rb
@@ -45,11 +45,9 @@ describe "iptables::add_udp_listen", :type => :define do
             :apply_to    => 'ipv6'
           }}
           it{
-            skip( 'FIXME: validate_net_list() fails *any* IPv6 CIDR (but accepts IPv4)' )
             is_expected.to create_iptables__add_udp_listen('allow_udp_1234').with_dports('1234')
           }
           it{
-            skip( 'FIXME: validate_net_list() fails *any* IPv6 CIDR (but accepts IPv4)' )
             is_expected.to create_iptables_rule('udp_allow_udp_1234')
           }
         end


### PR DESCRIPTION
- Eliminated use of deprecated Puppet.newtype
- Fixed bug in the set provider for the xt_recent type that required manual
  modifications to the permissions for the /sys/module/xt_recent/parameters/*
  files, in order for the scanblock capability to be enabled.
- Fixed bugs in the xt_recent type and its set provider that caused
  Puppet to believe /sys/module/xt_recent/parameters/ip_list_perms
  file content had changed when it had not.
- Updated to compliance_markup version 2
- Expanded acceptance tests

SIMP-1884 #close