### PR TITLE
(SIMP-2421) Iptables should accept any and ALL for trusted nets

### DIFF
--- a/manifests/listen/all.pp
+++ b/manifests/listen/all.pp
@@ -62,11 +62,12 @@
 #   Set to ``any`` to allow all networks
 #
 define iptables::listen::all (
-  Boolean                             $first        = false,
-  Boolean                             $absolute     = false,
-  Integer[0]                          $order        = 11,
-  Enum['ipv4','ipv6','all','auto']    $apply_to     = 'auto',
-  Enum['any','ALL',Simplib::Netlist]  $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Boolean                           $first        = false,
+  Boolean                           $absolute     = false,
+  Integer[0]                        $order        = 11,
+  Enum['ipv4','ipv6','all','auto']  $apply_to     = 'auto',
+  Variant[Enum['any','ALL'],
+    Simplib::Netlist]               $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ){
   iptables_rule { "all_${name}":
     first    => $first,

--- a/manifests/listen/all.pp
+++ b/manifests/listen/all.pp
@@ -62,11 +62,11 @@
 #   Set to ``any`` to allow all networks
 #
 define iptables::listen::all (
-  Boolean                          $first        = false,
-  Boolean                          $absolute     = false,
-  Integer[0]                       $order        = 11,
-  Enum['ipv4','ipv6','all','auto'] $apply_to     = 'auto',
-  Simplib::Netlist                 $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Boolean                             $first        = false,
+  Boolean                             $absolute     = false,
+  Integer[0]                          $order        = 11,
+  Enum['ipv4','ipv6','all','auto']    $apply_to     = 'auto',
+  Enum['any','ALL',Simplib::Netlist]  $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ){
   iptables_rule { "all_${name}":
     first    => $first,

--- a/manifests/listen/icmp.pp
+++ b/manifests/listen/icmp.pp
@@ -71,12 +71,12 @@
 #   Set to ``any`` to allow all networks
 #
 define iptables::listen::icmp (
-  Variant[Array[String],String]    $icmp_types,
-  Boolean                          $first        = false,
-  Boolean                          $absolute     = false,
-  Integer[0]                       $order        = 11,
-  Enum['ipv4','ipv6','all','auto'] $apply_to     = 'auto',
-  Simplib::Netlist                 $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Variant[Array[String],String]      $icmp_types,
+  Boolean                            $first        = false,
+  Boolean                            $absolute     = false,
+  Integer[0]                         $order        = 11,
+  Enum['ipv4','ipv6','all','auto']   $apply_to     = 'auto',
+  Enum['any','ALL',Simplib::Netlist] $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ) {
   iptables_rule { "icmp_${name}":
     first    => $first,

--- a/manifests/listen/icmp.pp
+++ b/manifests/listen/icmp.pp
@@ -76,7 +76,8 @@ define iptables::listen::icmp (
   Boolean                            $absolute     = false,
   Integer[0]                         $order        = 11,
   Enum['ipv4','ipv6','all','auto']   $apply_to     = 'auto',
-  Enum['any','ALL',Simplib::Netlist] $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Variant[Enum['any','ALL'],
+    Simplib::Netlist]                $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ) {
   iptables_rule { "icmp_${name}":
     first    => $first,

--- a/manifests/listen/tcp_stateful.pp
+++ b/manifests/listen/tcp_stateful.pp
@@ -73,7 +73,8 @@ define iptables::listen::tcp_stateful (
   Boolean                            $absolute     = false,
   Integer[0]                         $order        = 11,
   Enum['ipv4','ipv6','all','auto']   $apply_to     = 'auto',
-  Enum['any','ALL',Simplib::Netlist] $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Variant[Enum['any','ALL'],
+    Simplib::Netlist]                $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ) {
   $_protocol = 'tcp'
 

--- a/manifests/listen/tcp_stateful.pp
+++ b/manifests/listen/tcp_stateful.pp
@@ -68,12 +68,12 @@
 #   Set to ``any`` to allow all networks
 #
 define iptables::listen::tcp_stateful (
-  Iptables::DestPort               $dports,
-  Boolean                          $first        = false,
-  Boolean                          $absolute     = false,
-  Integer[0]                       $order        = 11,
-  Enum['ipv4','ipv6','all','auto'] $apply_to     = 'auto',
-  Simplib::Netlist                 $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Iptables::DestPort                 $dports,
+  Boolean                            $first        = false,
+  Boolean                            $absolute     = false,
+  Integer[0]                         $order        = 11,
+  Enum['ipv4','ipv6','all','auto']   $apply_to     = 'auto',
+  Enum['any','ALL',Simplib::Netlist] $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ) {
   $_protocol = 'tcp'
 

--- a/manifests/listen/udp.pp
+++ b/manifests/listen/udp.pp
@@ -73,7 +73,8 @@ define iptables::listen::udp (
   Boolean                              $absolute     = false,
   Integer[0]                           $order        = 11,
   Enum['ipv4','ipv6','all','auto']     $apply_to     = 'auto',
-  Enum['any','ALL', Simplib::Netlist]  $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Variant[Enum['any','ALL'],
+    Simplib::Netlist]  $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ) {
   $_protocol = 'udp'
 

--- a/manifests/listen/udp.pp
+++ b/manifests/listen/udp.pp
@@ -68,12 +68,12 @@
 #   Set to ``any`` to allow all networks
 #
 define iptables::listen::udp (
-  Iptables::DestPort               $dports,
-  Boolean                          $first        = false,
-  Boolean                          $absolute     = false,
-  Integer[0]                       $order        = 11,
-  Enum['ipv4','ipv6','all','auto'] $apply_to     = 'auto',
-  Simplib::Netlist                 $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
+  Iptables::DestPort                   $dports,
+  Boolean                              $first        = false,
+  Boolean                              $absolute     = false,
+  Integer[0]                           $order        = 11,
+  Enum['ipv4','ipv6','all','auto']     $apply_to     = 'auto',
+  Enum['any','ALL', Simplib::Netlist]  $trusted_nets = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })
 ) {
   $_protocol = 'udp'
 


### PR DESCRIPTION
  * add 'any' and 'ALL' to the type for trusted_nets in IP tables
    listen rules.

SIMP-2421 #close