### PR TITLE
(SIMP-3311) Fixed IPTables scanblock rule ordering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Mon Dec 04 2017 Some Dude <7zbayf+sw1l67jjhlbk@sharklasers.com> - 6.1.0-0
+- Fixed a bug in the order of the IPTables rules in scanblock module
+  - Previously, IPTables would not block connections from banned IPs that
+    were accessing open ports.
+
 * Thu Nov 30 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.0-0
 - Added the ability to ignore interfaces using the 'ignore' regex array
 - Fixed issues with ignoring rules and added some optimization
@@ -8,7 +13,7 @@
 - Updated iptables::listen::tcp_stateful example to pass valid
   Iptables::DestPort types to dports
 
-* Wed May 24 2017 Brandon Riden <brandon.riden@onyxpoint.com> - 6.0.2-0
+* Wed May 24 2017 Brandon Riden <brandon.riden@onyxpoint.com> - 6.0.1-0
 - Added a workaround for Puppet 4.10 type issues
   - There was a bug in Puppet where all lookup() Hash keys were being converted
     into Strings even if they were another data type

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,7 +1,0 @@
-Obsoletes: pupmod-ip6tables >= 0.0.1
-Obsoletes: pupmod-iptables-test >= 0.0.1
-Provides: pupmod-simp-ip6tables
-Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
-Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
-Requires: pupmod-simp-simplib < 4.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0

--- a/manifests/rules/scanblock.pp
+++ b/manifests/rules/scanblock.pp
@@ -113,7 +113,7 @@ class iptables::rules::scanblock (
 
   if $enable {
     iptables_rule{'scanblock':
-      order    => 28,
+      order    => 7,
       header   => false,
       apply_to => 'all',
       # lint:ignore:only_variable_string

--- a/manifests/rules/scanblock.pp
+++ b/manifests/rules/scanblock.pp
@@ -112,13 +112,12 @@ class iptables::rules::scanblock (
   }
 
   if $enable {
-    iptables_rule{'scanblock':
-      order    => 7,
+    iptables_rule{'attk_check':
+      order    => 28,
       header   => false,
       apply_to => 'all',
       # lint:ignore:only_variable_string
       content  => @("EOM")
-        -A LOCAL-INPUT -m recent --update --seconds ${update_interval} --name BANNED --rsource -j DROP
         -A LOCAL-INPUT -m state --state NEW -j ATTK_CHECK
         -A ATTACKED -m limit --limit ${logs_per_minute}/min -j LOG --log-prefix "IPT: (Rule ATTACKED): "
         -A ATTACKED -m recent --set --name BANNED --rsource -j DROP
@@ -127,6 +126,17 @@ class iptables::rules::scanblock (
         |EOM
     }
     # lint:endignore
+    iptables_rule{'ban_check':
+      order    => 7,
+      header   => false,
+      apply_to => 'all',
+      # lint:ignore:only_variable_string
+      content  => @("EOM")
+        -A LOCAL-INPUT -m recent --update --seconds ${update_interval} --name BANNED --rsource -j DROP
+        |EOM
+    }
+    # lint:endignore
+
   }
 
   class { 'iptables::rules::mod_recent':

--- a/manifests/rules/scanblock.pp
+++ b/manifests/rules/scanblock.pp
@@ -126,17 +126,12 @@ class iptables::rules::scanblock (
         |EOM
     }
     # lint:endignore
+
     iptables_rule{'ban_check':
       order    => 7,
-      header   => false,
       apply_to => 'all',
-      # lint:ignore:only_variable_string
-      content  => @("EOM")
-        -A LOCAL-INPUT -m recent --update --seconds ${update_interval} --name BANNED --rsource -j DROP
-        |EOM
+      content  => "-m recent --update --seconds ${update_interval} --name BANNED --rsource -j DROP"
     }
-    # lint:endignore
-
   }
 
   class { 'iptables::rules::mod_recent':


### PR DESCRIPTION
scanblock rules would not properly ban hosts from
open ports due to rule ordering in IPTables. Default
order is now 7 instead of 28, right before the SSH
rule in IPTables.

SIMP-3311 #close