### PR TITLE
(SIMP-3498) Updated listen examples

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * Thu Aug 10 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.3-0
-- Updated iptables::listen::tcp_stateful and iptables::listen::udp
-  examples to pass valid Iptables::DestPort types to dports
+- Updated iptables::listen::tcp_stateful example to pass valid
+  Iptables::DestPort types to dports
 
 * Wed May 24 2017 Brandon Riden <brandon.riden@onyxpoint.com> - 6.0.2-0
 - Added a workaround for Puppet 4.10 type issues

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Aug 10 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.3-0
+- Updated iptables::listen::tcp_stateful and iptables::listen::udp
+  examples to pass valid Iptables::DestPort types to dports
+
 * Wed May 24 2017 Brandon Riden <brandon.riden@onyxpoint.com> - 6.0.2-0
 - Added a workaround for Puppet 4.10 type issues
   - There was a bug in Puppet where all lookup() Hash keys were being converted

--- a/manifests/listen/tcp_stateful.pp
+++ b/manifests/listen/tcp_stateful.pp
@@ -3,7 +3,7 @@
 # @example Provide Access to Specific Ports
 #   iptables::listen::tcp_stateful { 'example':
 #     trusted_nets => [ '1.2.3.4', '5.6.7.8' ],
-#     dports => [ 5, 1024:65535 ]
+#     dports => [ 5, '1024:65535' ]
 #   }
 #
 #   ### Result

--- a/manifests/listen/tcp_stateful.pp
+++ b/manifests/listen/tcp_stateful.pp
@@ -3,7 +3,7 @@
 # @example Provide Access to Specific Ports
 #   iptables::listen::tcp_stateful { 'example':
 #     trusted_nets => [ '1.2.3.4', '5.6.7.8' ],
-#     dports => [ '5', '1024:65535' ]
+#     dports => [ 5, 1024:65535 ]
 #   }
 #
 #   ### Result

--- a/manifests/listen/udp.pp
+++ b/manifests/listen/udp.pp
@@ -3,7 +3,7 @@
 # @example Allow UDP Access to ``1.2.3.4`` and ``5.6.7.8``
 #   iptables::listen::udp { 'example':
 #     trusted_nets => [ '1.2.3.4', '5.6.7.8' ],
-#     dports       => [ 5, 1024:65535 ]
+#     dports       => [ 5, '1024:65535' ]
 #   }
 #
 #   ### Result

--- a/manifests/listen/udp.pp
+++ b/manifests/listen/udp.pp
@@ -3,7 +3,7 @@
 # @example Allow UDP Access to ``1.2.3.4`` and ``5.6.7.8``
 #   iptables::listen::udp { 'example':
 #     trusted_nets => [ '1.2.3.4', '5.6.7.8' ],
-#     dports       => [ 5, '1024:65535' ]
+#     dports       => [ 5, 1024:65535 ]
 #   }
 #
 #   ### Result

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -49,6 +49,10 @@ describe 'iptables' do
         end
 
         context "default spoofing prevention" do
+          let (:facts) do facts.merge({
+            :ipv6_enabled => true
+            })
+          end
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_iptables_rule('prevent_ipv6_localhost_spoofing').with_apply_to('ipv6') }
         end

--- a/spec/defines/listen/udp_spec.rb
+++ b/spec/defines/listen/udp_spec.rb
@@ -9,12 +9,12 @@ describe "iptables::listen::udp", :type => :define do
         end
 
         describe "with IPv4 trusted_nets" do
-          let( :title  ){ 'allow_udp_1234' }
+          let( :title  ){ 'allow_udp_range' }
           let( :params ){{
             :trusted_nets => ['10.0.2.0'],
-            :dports       => 1234
+            :dports       => [1234,'9999:20000']
           }}
-          it { is_expected.to create_iptables__listen__udp('allow_udp_1234').with_dports(1234) }
+          it { is_expected.to create_iptables__listen__udp("allow_udp_range").with_dports(params[:dports]) }
         end
 
         describe "with IPv4 trusted_netsi in CIDR notation" do


### PR DESCRIPTION
- Updated iptables::listen::tcp_stateful and iptables::listen::udp
  examples to pass valid Iptables::DestPort types to dports

SIMP-3498 #close