### PR TITLE
iptables: Move ports logic to define

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,9 +18,9 @@
   script:
     - bundle exec rake check:dot_underscore
     - bundle exec rake check:test_file
-    - bundle exec rake pkg:check_version
     - bundle exec rake lint
     - bundle exec rake metadata_lint
+    - bundle exec rake pkg:check_version
     - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake pkg:create_tag_changelog
     - bundle exec puppet module build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,91 +11,50 @@
   before_script:
     - gem install bundler
     - rm -f Gemfile.lock
+    - rm -rf pkg/
     - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
 
-.syntax_checks: &syntax_checks
+.static_tests: &static_tests
   script:
-    - bundle exec rake syntax
     - bundle exec rake check:dot_underscore
     - bundle exec rake check:test_file
     - bundle exec rake pkg:check_version
-    - bundle exec rake compare_latest_tag
-
-.spec_tests: &spec_tests
-  script:
-    - bundle exec rake spec
+    - bundle exec rake lint
+    - bundle exec rake metadata_lint
+    - bundle exec rake pkg:compare_latest_tag
+    - bundle exec rake pkg:create_tag_changelog
+    - bundle exec puppet module build
+    - bundle exec rake test
 
 stages:
-  - syntax
   - unit
   - acceptance
   - deploy
 
-puppet-syntax:
-  stage: syntax
-  tags:
-    - docker
-  image: ruby:2.4
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *syntax_checks
-
 # Puppet 4
-unit-ruby-2.1.9:
+puppet-gemfile:
   stage: unit
   tags:
     - docker
   image: ruby:2.1.9
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *spec_tests
-
-# Puppet 5
-unit-ruby-2.4.1:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.4
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *spec_tests
+  <<: *static_tests
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax:
-  stage: syntax
-  tags:
-    - docker
-  image: ruby:2.1
-  variables:
-    PUPPET_VERSION: '4.7'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *syntax_checks
-
-unit-puppet4.7-ruby-2.1:
+puppet-4.7:
   stage: unit
   tags:
     - docker
-  image: ruby:2.1
+  image: ruby:2.1.9
   variables:
     PUPPET_VERSION: '4.7'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *spec_tests
+  <<: *static_tests
 
-puppet5-syntax:
-  stage: syntax
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '5.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *syntax_checks
-
-unit-puppet5-ruby-2.4:
+puppet-5:
   stage: unit
   tags:
     - docker
@@ -104,14 +63,27 @@ unit-puppet5-ruby-2.4:
     PUPPET_VERSION: '5.0'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *spec_tests
-  allow_failure: true
+  <<: *static_tests
 
-acceptance-default:
+default:
   stage: acceptance
   tags:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
-    - bundle exec rake beaker:suites[default]
+    - bundle exec rake beaker:suites
+
+default-fips:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,8 +2,4 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
 --no-trailing_comma-check
-# This is here because the code can't handle lookups in parameters and we have
-# a LOT of those
---no-parameter_order-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ jobs:
       script:
         - bundle exec rake check:dot_underscore
         - bundle exec rake check:test_file
-        - bundle exec rake pkg:check_version
         - bundle exec rake lint
         - bundle exec rake metadata_lint
+        - bundle exec rake pkg:check_version
         - bundle exec rake pkg:compare_latest_tag
         - bundle exec rake pkg:create_tag_changelog
         - bundle exec puppet module build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,60 +8,82 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
+sudo: false
 
 bundler_args: --without development system_tests --path .vendor
 
+
 notifications:
   email: false
+
+addons:
+  apt:
+    packages:
+      - rpm
 
 before_install:
   - rm -f Gemfile.lock
 
 jobs:
-  fast_finish: true
-  allow_failures:
-    - env: PUPPET_VERSION="~> 5.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
-
   include:
-    - stage: test
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
       script:
-        - bundle exec rake test
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake lint
+        - bundle exec rake metadata_lint
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
+        - bundle exec puppet module build
 
-    - stage: test
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.7.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
       script:
-        - bundle exec rake test
+        - bundle exec rake spec
 
-    - stage: test
+    - stage: spec
       rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.8.2" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
       script:
-        - bundle exec rake compare_latest_tag
-        - bundle exec rake test
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
       before_deploy:
-        - 'bundle exec rake metadata_lint'
-        - 'bundle exec rake clobber'
-        - 'bundle exec rake spec_clean'
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
         - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
       deploy:
-        - provider: puppetforge
-          user: simp
-          password:
-            secure: "pBJKQhmfxB7y83FLgY1a5ZeG9puUfxvZXYTNyEmHMraZ7kttLkUlB15vjIR24fWd5ctR9xc+AWHpn78hLdV7JQ80gQZPaPgrM0lodlGHDuxGaLaZ3sJQdTrB9WE+zPKJbdY6CN1olHjPJ50AHWpdhgT+JPNs+lAJ4ACWyaanDEWY627cJpxrH3ehwdk3vim/BG9uUwMq7i140Y+gId+W1EBA2M0265rWPPmuS/92O4qF26o2iZElDcy9gpMsfgHsI2thLrVHE81I9whuKpw3Va+rUv+yhUKp4Jflxe+m28CY2CalVSoqTHLLTl7rT7EITS1l1y6ahBHo0lBjXXA2d1v2gO7thOhlaG7qH26GwUHa4KbxL8TAifnNZmLyFg0UOPpRzyli4y6KJyHNS0ri/C5ReqRtm+KP6Hd8XYYUssa7CPjqpuF9pgWDCFx2p4qHhI/ufAv6HftYlwJHRjEUwwat2e1jT81MExvp4jeAmjEaWtdYEKgt5YmuZVFNnUph1lGQjVnJEu/upfZ2pn/38HbbgDei0NeKgskhFZSpiOEbT6w4V9bn4mVwojQGuoY64hgAA5XpRkSvqHB+8z1sypBGKdq85oJhB6D/B6GGS1G9Du175HlqDllsBQJLPpwWeJrX/b8iDlTMnMdsehvaMCblLt59kzQxHSUU+7y53tw="
-          on:
-            tags: true
-            rvm: 2.1.9
-            condition: '($SKIP_FORGE_PUBLISH != true)'
         - provider: releases
           api_key:
             secure: "YLvt9oxynaTcWOqecxpFPacugxtQ/r4w+fu1gqBuiNDUrEuvQSzlVtcPFg5zg+MynTEfUhJNxzGTGFM8ZxnrSI88EMX5zaLTThUVXEnpHUk2uw7QNQ0Fa/pzjH1GWrcIkLAtgGuV8M6+rKi18ojaDGbzIa4yz3xGivS3AJczvr0M4+jsiVanMZZgYhRyhpYNW9oiVtk744hmNNwt34pwV6e8n8NCqQC1C3zgCazsSyv4b8gSV4NtuonL8wfbFsyTQcjdEJBIK43443qbFyIf8RnN7veJdu2b0eC8PVuhYhA/LcatmF9/F7nLPbIgYJL4NHUcu2vHux8wm1K2/1UuWb11C1a+HJm9kr8MK/LMwzKxYYb0IBd9/ciWme4zFlVCv4KxuEKdY6cwggPB0Q8Wf/dXCkC5MBfoRw6crHHPfYa53Ogag2bchgtl/5qntE5hnI3Gf828cR5+O2zePLCT+4LbOFoezho1bAaV1AOy0rXoy5XqooSp69URY37viKjJqFnHu8TVyBfwB8xkIjIP45XSznYcZbQFVnJGerci8/089h9kjjo98FVZsLtFP8KSrerWIBJrHk2oRDqHgKFG89Obd+AB2u6tT5POf2QRNGoqy3yqJBiaejgFz00Ey3pHzR0Vi8pnDEgEidsP0RhxPmjIUXgX0gMunbTgt8T4+/M="
           skip_cleanup: true
           on:
             tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "pBJKQhmfxB7y83FLgY1a5ZeG9puUfxvZXYTNyEmHMraZ7kttLkUlB15vjIR24fWd5ctR9xc+AWHpn78hLdV7JQ80gQZPaPgrM0lodlGHDuxGaLaZ3sJQdTrB9WE+zPKJbdY6CN1olHjPJ50AHWpdhgT+JPNs+lAJ4ACWyaanDEWY627cJpxrH3ehwdk3vim/BG9uUwMq7i140Y+gId+W1EBA2M0265rWPPmuS/92O4qF26o2iZElDcy9gpMsfgHsI2thLrVHE81I9whuKpw3Va+rUv+yhUKp4Jflxe+m28CY2CalVSoqTHLLTl7rT7EITS1l1y6ahBHo0lBjXXA2d1v2gO7thOhlaG7qH26GwUHa4KbxL8TAifnNZmLyFg0UOPpRzyli4y6KJyHNS0ri/C5ReqRtm+KP6Hd8XYYUssa7CPjqpuF9pgWDCFx2p4qHhI/ufAv6HftYlwJHRjEUwwat2e1jT81MExvp4jeAmjEaWtdYEKgt5YmuZVFNnUph1lGQjVnJEu/upfZ2pn/38HbbgDei0NeKgskhFZSpiOEbT6w4V9bn4mVwojQGuoY64hgAA5XpRkSvqHB+8z1sypBGKdq85oJhB6D/B6GGS1G9Du175HlqDllsBQJLPpwWeJrX/b8iDlTMnMdsehvaMCblLt59kzQxHSUU+7y53tw="
+          on:
+            tags: true
+            rvm: 2.4.1
             condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
+* Mon Jan 22 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.1
+- Fixed bugs in the chain retention and optimization code that would cause
+  iptables to fail to reload in some situations.
+
 * Mon Jan 22 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.1
-- This commit moves the logic that parses the iptables::ports hash into a
+- This commit moves the logic that parses the `iptables::ports` Hash into a
   define, to make it possible to use the same hash format in other modules
   without copying code.
-- There was also a bug where compilation would fail if proto was specified in
-  the defaults section of the hash.
+- There was also a bug where compilation would fail if `proto` was specified in
+  the defaults section of the Hash.
 
 * Mon Dec 04 2017 Some Dude <7zbayf+sw1l67jjhlbk@sharklasers.com> - 6.1.0-0
 - Fixed a bug in the order of the IPTables rules in scanblock module

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Mon Jan 22 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.1
+- This commit moves the logic that parses the iptables::ports hash into a
+  define, to make it possible to use the same hash format in other modules
+  without copying code.
+- There was also a bug where compilation would fail if proto was specified in
+  the defaults section of the hash.
+
 * Mon Dec 04 2017 Some Dude <7zbayf+sw1l67jjhlbk@sharklasers.com> - 6.1.0-0
 - Fixed a bug in the order of the IPTables rules in scanblock module
   - Previously, IPTables would not block connections from banned IPs that

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.2')
 end
 
 group :development do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,47 +121,7 @@ class iptables (
   }
 
   if $ports {
-    # extract defaults and remove that hash from iteration
-    if $ports['defaults'].is_a(Hash) {
-      $defaults  = $ports['defaults']
-      $raw_ports = $ports - 'defaults'
-    }
-    else {
-      $defaults  = {}
-      $raw_ports = $ports
-    }
-
-    # https://docs.puppet.com/puppet/latest/reference/lang_resources_advanced.html#implementing-the-createresources-function
-    $raw_ports.each |$port, $options| {
-      $_port = Integer.new($port)
-      $name_to_param = {
-        'dports' => [$_port],
-      }
-
-      if $options.is_a(Hash) {
-        $proto = $options['proto']
-        $args  = ($options - 'proto') + $name_to_param
-      }
-      else {
-        $proto = 'tcp'
-        $args  = $name_to_param
-      }
-
-      case $proto {
-        default: {
-          iptables::listen::tcp_stateful {
-            default:        * => $defaults;
-            "port_${port}": * => $args;
-          }
-        }
-        'udp': {
-          iptables::listen::udp {
-            default:        * => $defaults;
-            "port_${port}": * => $args;
-          }
-        }
-      }
-    }
+    iptables::ports {'iptables': ports => $ports }
   }
 
 }

--- a/manifests/ports.pp
+++ b/manifests/ports.pp
@@ -1,5 +1,5 @@
 # A define to allow for the standardization of the
-#  iptables::ports syntax across modules 
+#  iptables::ports syntax across modules
 #
 # @param ports
 #   A hash with structure as defined below that will open ports based on the
@@ -27,7 +27,6 @@ define iptables::ports (
     $raw_ports = $ports
   }
 
-  # https://docs.puppet.com/puppet/latest/reference/lang_resources_advanced.html#implementing-the-createresources-function
   $raw_ports.each |$port, $options| {
     $_port = Integer.new($port)
     $name_to_param = {
@@ -35,24 +34,36 @@ define iptables::ports (
     }
 
     if $options.is_a(Hash) {
-      $proto = $options['proto']
-      $args  = ($options - 'proto') + $name_to_param
+      if $options['proto'] {
+        $proto = $options['proto']
+      }
+      else {
+        $proto = $defaults['proto']
+      }
+      $_defaults = $defaults - 'proto'
+      $args      = ($options - 'proto') + $name_to_param
     }
     else {
-      $proto = 'tcp'
+      if $defaults['proto'] {
+        $proto = $defaults['proto']
+      }
+      else {
+        $proto = 'tcp'
+      }
+      $_defaults = $defaults - 'proto'
       $args  = $name_to_param
     }
 
     case $proto {
       default: {
         iptables::listen::tcp_stateful {
-          default:        * => $defaults;
+          default:        * => $_defaults;
           "port_${port}": * => $args;
         }
       }
       'udp': {
         iptables::listen::udp {
-          default:        * => $defaults;
+          default:        * => $_defaults;
           "port_${port}": * => $args;
         }
       }

--- a/manifests/ports.pp
+++ b/manifests/ports.pp
@@ -1,0 +1,61 @@
+# A define to allow for the standardization of the
+#  iptables::ports syntax across modules 
+#
+# @param ports
+#   A hash with structure as defined below that will open ports based on the
+#   structure of the hash.
+#   @example An example section of hieradata:
+#     iptables::ports:
+#       defaults:
+#         apply_to: ipv4
+#       80:
+#       53:
+#         proto: udp
+#       443:
+#         apply_to: ipv6
+#
+define iptables::ports (
+  Hash $ports,
+) {
+  # extract defaults and remove that hash from iteration
+  if $ports['defaults'].is_a(Hash) {
+    $defaults  = $ports['defaults']
+    $raw_ports = $ports - 'defaults'
+  }
+  else {
+    $defaults  = {}
+    $raw_ports = $ports
+  }
+
+  # https://docs.puppet.com/puppet/latest/reference/lang_resources_advanced.html#implementing-the-createresources-function
+  $raw_ports.each |$port, $options| {
+    $_port = Integer.new($port)
+    $name_to_param = {
+      'dports' => [$_port],
+    }
+
+    if $options.is_a(Hash) {
+      $proto = $options['proto']
+      $args  = ($options - 'proto') + $name_to_param
+    }
+    else {
+      $proto = 'tcp'
+      $args  = $name_to_param
+    }
+
+    case $proto {
+      default: {
+        iptables::listen::tcp_stateful {
+          default:        * => $defaults;
+          "port_${port}": * => $args;
+        }
+      }
+      'udp': {
+        iptables::listen::udp {
+          default:        * => $defaults;
+          "port_${port}": * => $args;
+        }
+      }
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,7 +9,6 @@ describe 'iptables' do
 
       context "on #{os}" do
         context "iptables class without any parameters" do
-          let(:params) {{ }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('iptables').with_enable(true) }
           it { is_expected.to contain_package('iptables').with_ensure('latest') }
@@ -26,6 +25,7 @@ describe 'iptables' do
 
         context "iptables class with firewall enabled from hiera via 'simp_options::firewall: true'" do
           let(:hieradata) { "firewall__enable" }
+
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('iptables').with_enable(true) }
 
@@ -49,10 +49,8 @@ describe 'iptables' do
         end
 
         context "default spoofing prevention" do
-          let (:facts) do facts.merge({
-            :ipv6_enabled => true
-            })
-          end
+          let (:facts) { facts.merge( ipv6_enabled: true ) }
+
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_iptables_rule('prevent_ipv6_localhost_spoofing').with_apply_to('ipv6') }
         end

--- a/spec/defines/listen/ports_spec.rb
+++ b/spec/defines/listen/ports_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper.rb'
+
+describe "iptables::ports", :type => :define do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let(:title) { 'iptables' }
+
+      context 'containing a defaults section' do
+        let(:params) {{
+          'ports' => {
+            'defaults' => {
+              'apply_to' => 'ipv4'
+            },
+            '80': nil,
+            '53': {
+              'proto' => 'udp'
+            },
+            '443': {
+              'apply_to' => 'ipv6'
+            }
+          }
+        }}
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'ipv4') }
+        it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'ipv4') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
+      end
+
+      context 'a hash without a default section' do
+        let(:params) {{
+          'ports' => {
+            '80': nil,
+            '53': {
+              'proto' => 'udp'
+            },
+            '443' => {
+              'apply_to' => 'ipv6'
+            }
+          }}
+        }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
+      end
+
+      context 'a hash containing an invalid parameter' do
+        let(:params) {{
+          'ports' => {
+            'defaults' => {
+              'apply_to' => 'ipv4'
+            },
+            '80' => nil,
+            '53' => {
+              'param' => 'udp'
+            },
+            '443' => {
+              'apply_to' => 'ipv6'
+            }
+          }
+        }}
+        it { is_expected.to raise_error(/param/) }
+      end
+    end
+  end
+end

--- a/spec/defines/ports_spec.rb
+++ b/spec/defines/ports_spec.rb
@@ -8,11 +8,29 @@ describe "iptables::ports", :type => :define do
       end
       let(:title) { 'iptables' }
 
+      context 'a hash without a default section' do
+        let(:params) {{
+          'ports' => {
+            '80': nil,
+            '53': {
+              'proto' => 'udp'
+            },
+            '443' => {
+              'apply_to' => 'ipv6'
+            }
+          }
+        }}
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
+      end
+
       context 'containing a defaults section' do
         let(:params) {{
           'ports' => {
             'defaults' => {
-              'apply_to' => 'ipv4'
+              'apply_to' => 'ipv4',
+              'proto'    => 'tcp'
             },
             '80': nil,
             '53': {
@@ -25,23 +43,6 @@ describe "iptables::ports", :type => :define do
         }}
         it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'ipv4') }
         it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'ipv4') }
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
-      end
-
-      context 'a hash without a default section' do
-        let(:params) {{
-          'ports' => {
-            '80': nil,
-            '53': {
-              'proto' => 'udp'
-            },
-            '443' => {
-              'apply_to' => 'ipv6'
-            }
-          }}
-        }
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'auto') }
-        it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'auto') }
         it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
       end
 

--- a/spec/defines/ports_spec.rb
+++ b/spec/defines/ports_spec.rb
@@ -11,8 +11,8 @@ describe "iptables::ports", :type => :define do
       context 'a hash without a default section' do
         let(:params) {{
           'ports' => {
-            '80': nil,
-            '53': {
+            '80' => nil,
+            '53' => {
               'proto' => 'udp'
             },
             '443' => {
@@ -32,11 +32,11 @@ describe "iptables::ports", :type => :define do
               'apply_to' => 'ipv4',
               'proto'    => 'tcp'
             },
-            '80': nil,
-            '53': {
+            '80'=> nil,
+            '53'=> {
               'proto' => 'udp'
             },
-            '443': {
+            '443' => {
               'apply_to' => 'ipv6'
             }
           }


### PR DESCRIPTION
This commit moves the logic that parses the `iptables::ports` hash into a define, to make it possible to use the same hash format in other modules without copying code. 

There was also a bug where compilation would fail if `proto` was specified in the defaults section of the hash.