### PR TITLE
WIP (SIMP-4429) iptables: ports hash with many protos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 20 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.2
+- Move iptables::ports logic into a function to allow ports to be specified
+  in multiple protocols
+
 * Mon Jan 22 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.1
 - Fixed bugs in the chain retention and optimization code that would cause
   iptables to fail to reload in some situations.

--- a/lib/puppet/functions/iptables/parse_ports.rb
+++ b/lib/puppet/functions/iptables/parse_ports.rb
@@ -1,4 +1,7 @@
-# @param ports
+# Convert a hash with a user friendly format to a hash that can be consumed to
+#   create Puppet resources
+#
+# @param ports_hash
 #   A hash with structure as defined below that will open ports based on the
 #   structure of the hash.
 #   @example An example section of hieradata:
@@ -19,23 +22,30 @@ Puppet::Functions.create_function(:'iptables::parse_ports') do
   end
 
   def parse(ports_hash)
+    # ports_hash comes in frozen, so you can't modify it
+    ports_hash_dup = ports_hash.dup
+
     # extract defaults key and remove it from iteration
-    defaults = ports_hash.delete('defaults') || {}
+    defaults = ports_hash_dup.delete('defaults') || {}
     ports    = {}
 
     # go through and find all possible permutations of ports and protocols
-    ports_hash.each do |port,options|
+    ports_hash_dup.each do |port,options|
       if options.is_a? Hash
-        proto = options['proto'] || defaults['proto'] || 'tcp'
-        options.delete('proto')
-      elsif options == 'nil'
+        # same deal with options
+        options_dup = options.dup
+        proto = options_dup['proto'] || defaults['proto'] || 'tcp'
+        options_dup.delete('proto')
+      elsif options == 'nil' or options.nil?
         proto = defaults['proto'] || 'tcp'
-        options = {}
+        options_dup = {}
       end
-      defaults.delete('proto')
+      # ... and defaults
+      defaults_dup = defaults.dup
+      defaults_dup.delete('proto')
 
       Array(proto).each do |po|
-        args = defaults.merge(options)
+        args = defaults_dup.to_h.merge(options_dup)
         ports["port_#{port}_#{po}"] = { 'dports' => [port.to_i] }.merge(args)
       end
     end

--- a/lib/puppet/functions/iptables/parse_ports.rb
+++ b/lib/puppet/functions/iptables/parse_ports.rb
@@ -1,0 +1,44 @@
+# @param ports
+#   A hash with structure as defined below that will open ports based on the
+#   structure of the hash.
+#   @example An example section of hieradata:
+#     iptables::ports:
+#       defaults:
+#         apply_to: ipv4
+#       80:
+#       53:
+#         proto: udp
+#       443:
+#         apply_to: ipv6
+#       514:
+#         proto: [udp,tcp]
+#
+Puppet::Functions.create_function(:'iptables::parse_ports') do
+  dispatch :parse do
+    required_param 'Hash', :ports_hash
+  end
+
+  def parse(ports_hash)
+    # extract defaults key and remove it from iteration
+    defaults = ports_hash.delete('defaults') || {}
+    ports    = {}
+
+    # go through and find all possible permutations of ports and protocols
+    ports_hash.each do |port,options|
+      if options.is_a? Hash
+        proto = options['proto'] || defaults['proto'] || 'tcp'
+        options.delete('proto')
+      elsif options == 'nil'
+        proto = defaults['proto'] || 'tcp'
+        options = {}
+      end
+      defaults.delete('proto')
+
+      Array(proto).each do |po|
+        args = defaults.merge(options)
+        ports["port_#{port}_#{po}"] = { 'dports' => [port.to_i] }.merge(args)
+      end
+    end
+    ports
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'yaml'
 
 describe 'iptables' do
   context  'supported operating systems' do
@@ -54,26 +55,6 @@ describe 'iptables' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_iptables_rule('prevent_ipv6_localhost_spoofing').with_apply_to('ipv6') }
         end
-
-        context 'with a provided iptables::ports hash' do
-          context 'containing a defaults section' do
-            let(:hieradata){ 'iptables__ports' }
-            it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with({ :apply_to => 'ipv4'}) }
-            it { is_expected.to create_iptables__listen__udp('port_53').with({ :apply_to => 'ipv4'}) }
-            it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with({ :apply_to => 'ipv6'}) }
-          end
-          context 'a hash without a default section' do
-            let(:hieradata){ 'iptables__ports_no_default' }
-            it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with({ :apply_to => 'auto'}) }
-            it { is_expected.to create_iptables__listen__udp('port_53').with({ :apply_to => 'auto'}) }
-            it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with({ :apply_to => 'ipv6'}) }
-          end
-          context 'a hash containing an invalid parameter' do
-            let(:hieradata){ 'iptables__ports_bad_param' }
-            it { is_expected.to raise_error(/param/) }
-          end
-        end
-
       end
     end
   end

--- a/spec/defines/ports_spec.rb
+++ b/spec/defines/ports_spec.rb
@@ -1,28 +1,33 @@
 require 'spec_helper.rb'
 
-describe "iptables::ports", :type => :define do
+describe 'iptables::ports', :type => :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) do
-        facts
-      end
       let(:title) { 'iptables' }
 
       context 'a hash without a default section' do
         let(:params) {{
           'ports' => {
-            '80' => nil,
+            '443' => {
+              'apply_to' => 'ipv6'
+            },
             '53' => {
               'proto' => 'udp'
             },
-            '443' => {
-              'apply_to' => 'ipv6'
-            }
+            '514' => {
+              'proto' => ['udp','tcp']
+            },
+            '80' => nil,
           }
         }}
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'auto') }
-        it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'auto') }
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
+        it { is_expected.to compile.with_all_deps }
+        # it { require 'pry';binding.pry }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_443_tcp').with(apply_to: 'ipv6') }
+        it { is_expected.to create_iptables__listen__udp('port_53_udp').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__udp('port_514_udp').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_514_tcp').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp').with(apply_to: 'auto') }
       end
 
       context 'containing a defaults section' do
@@ -32,18 +37,24 @@ describe "iptables::ports", :type => :define do
               'apply_to' => 'ipv4',
               'proto'    => 'tcp'
             },
-            '80'=> nil,
+            '443' => {
+              'apply_to' => 'ipv6'
+            },
             '53'=> {
               'proto' => 'udp'
             },
-            '443' => {
-              'apply_to' => 'ipv6'
-            }
+            '514' => {
+              'proto' => ['udp','tcp']
+            },
+            '80' => nil,
           }
         }}
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'ipv4') }
-        it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'ipv4') }
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_443_tcp').with(apply_to: 'ipv6') }
+        it { is_expected.to create_iptables__listen__udp('port_53_udp').with(apply_to: 'ipv4') }
+        it { is_expected.to create_iptables__listen__udp('port_514_udp').with(apply_to: 'ipv4') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_514_tcp').with(apply_to: 'ipv4') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp').with(apply_to: 'ipv4') }
       end
 
       context 'a hash containing an invalid parameter' do
@@ -52,13 +63,13 @@ describe "iptables::ports", :type => :define do
             'defaults' => {
               'apply_to' => 'ipv4'
             },
-            '80' => nil,
             '53' => {
               'param' => 'udp'
             },
             '443' => {
               'apply_to' => 'ipv6'
-            }
+            },
+            '80' => nil,
           }
         }}
         it { is_expected.to raise_error(/param/) }

--- a/spec/defines/ports_spec.rb
+++ b/spec/defines/ports_spec.rb
@@ -25,7 +25,10 @@ describe 'iptables::ports', :type => :define do
         it { is_expected.to create_iptables__listen__udp('port_53_udp').with(apply_to: 'auto') }
         it { is_expected.to create_iptables__listen__udp('port_514_udp').with(apply_to: 'auto') }
         it { is_expected.to create_iptables__listen__tcp_stateful('port_514_tcp').with(apply_to: 'auto') }
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp').with(apply_to: 'auto') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp').with(
+          apply_to: 'auto',
+          dports: [80]
+        ) }
       end
 
       context 'containing a defaults section' do
@@ -52,7 +55,10 @@ describe 'iptables::ports', :type => :define do
         it { is_expected.to create_iptables__listen__udp('port_53_udp').with(apply_to: 'ipv4') }
         it { is_expected.to create_iptables__listen__udp('port_514_udp').with(apply_to: 'ipv4') }
         it { is_expected.to create_iptables__listen__tcp_stateful('port_514_tcp').with(apply_to: 'ipv4') }
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp').with(apply_to: 'ipv4') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp').with(
+          apply_to: 'ipv4',
+          dports: [80]
+        ) }
       end
 
       context 'a hash containing an invalid parameter' do

--- a/spec/defines/ports_spec.rb
+++ b/spec/defines/ports_spec.rb
@@ -21,12 +21,10 @@ describe 'iptables::ports', :type => :define do
           }
         }}
         it { is_expected.to compile.with_all_deps }
-        # it { require 'pry';binding.pry }
         it { is_expected.to create_iptables__listen__tcp_stateful('port_443_tcp').with(apply_to: 'ipv6') }
         it { is_expected.to create_iptables__listen__udp('port_53_udp').with(apply_to: 'auto') }
         it { is_expected.to create_iptables__listen__udp('port_514_udp').with(apply_to: 'auto') }
         it { is_expected.to create_iptables__listen__tcp_stateful('port_514_tcp').with(apply_to: 'auto') }
-        it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp') }
         it { is_expected.to create_iptables__listen__tcp_stateful('port_80_tcp').with(apply_to: 'auto') }
       end
 

--- a/spec/fixtures/hieradata/iptables__ports.yaml
+++ b/spec/fixtures/hieradata/iptables__ports.yaml
@@ -1,9 +1,0 @@
----
-iptables::ports:
-  defaults:
-    apply_to: ipv4
-  80:
-  53:
-    proto: udp
-  443:
-    apply_to: ipv6

--- a/spec/fixtures/hieradata/iptables__ports_bad_param.yaml
+++ b/spec/fixtures/hieradata/iptables__ports_bad_param.yaml
@@ -1,9 +1,0 @@
----
-iptables::ports:
-  defaults:
-    apply_to: ipv4
-  80:
-  53:
-    param: udp
-  443:
-    apply_to: ipv6

--- a/spec/fixtures/hieradata/iptables__ports_no_default.yaml
+++ b/spec/fixtures/hieradata/iptables__ports_no_default.yaml
@@ -1,7 +1,0 @@
----
-iptables::ports:
-  80:
-  53:
-    proto: udp
-  443:
-    apply_to: ipv6

--- a/spec/functions/parse_ports_spec.rb
+++ b/spec/functions/parse_ports_spec.rb
@@ -4,29 +4,21 @@ describe 'iptables::parse_ports' do
 
   inputs = {
     'a hash without a default section' => {
-      '80'  => nil,
-      '53'  => { 'proto' => 'udp' },
+      '53'  => { 'proto'    => 'udp' },
       '443' => { 'apply_to' => 'ipv6' },
-      '514' => { 'proto' => ['udp','tcp'] }
+      '514' => { 'proto'    => ['udp','tcp'] },
+      '80'  => nil,
     },
     'containing a defaults section' => {
       'defaults' => {
         'apply_to' => 'ipv4',
         'proto'    => 'tcp'
       },
+      '53'  => { 'proto'    => 'udp' },
       '443' => { 'apply_to' => 'ipv6' },
-      '53'  => { 'proto' => 'udp' },
-      '514' => { 'proto' => ['udp','tcp'] },
+      '514' => { 'proto'    => ['udp','tcp'] },
       '80'  => nil,
     },
-    'a hash containing an invalid parameter' => {
-      'defaults' => {
-        'apply_to' => 'ipv4'
-      },
-      '53'  => { 'param' => 'udp' },
-      '443' => { 'apply_to' => 'ipv6' },
-      '80'  => nil,
-    }
   }
 
   outputs = {
@@ -44,20 +36,15 @@ describe 'iptables::parse_ports' do
       'port_514_tcp' => { 'dports' => [514], 'apply_to' => 'ipv4'},
       'port_80_tcp'  => { 'dports' => [80],  'apply_to' => 'ipv4'},
     },
-    'a hash containing an invalid parameter' => {
-      'port_53_tcp'  => { 'dports' => [53],  'apply_to' => 'ipv4', 'param' => 'udp'},
-      'port_443_tcp' => { 'dports' => [443], 'apply_to' => 'ipv6'},
-      'port_80_tcp'  => { 'dports' => [80],  'apply_to' => 'ipv4'},
-    },
   }
 
-  # inputs.keys.each do |test_name|
-  #   context test_name do
-  #     it {
-  #       is_expected.to run
-  #         .with_params(inputs[test_name])
-  #         .and_return(outputs[test_name])
-  #       }
-  #   end
-  # end
+  inputs.keys.each do |test_name|
+    context test_name do
+      it {
+        is_expected.to run
+          .with_params(inputs[test_name])
+          .and_return(outputs[test_name])
+        }
+    end
+  end
 end

--- a/spec/functions/parse_ports_spec.rb
+++ b/spec/functions/parse_ports_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe 'iptables::parse_ports' do
+
+  inputs = {
+    'a hash without a default section' => {
+      '80'  => nil,
+      '53'  => { 'proto' => 'udp' },
+      '443' => { 'apply_to' => 'ipv6' },
+      '514' => { 'proto' => ['udp','tcp'] }
+    },
+    'containing a defaults section' => {
+      'defaults' => {
+        'apply_to' => 'ipv4',
+        'proto'    => 'tcp'
+      },
+      '443' => { 'apply_to' => 'ipv6' },
+      '53'  => { 'proto' => 'udp' },
+      '514' => { 'proto' => ['udp','tcp'] },
+      '80'  => nil,
+    },
+    'a hash containing an invalid parameter' => {
+      'defaults' => {
+        'apply_to' => 'ipv4'
+      },
+      '53'  => { 'param' => 'udp' },
+      '443' => { 'apply_to' => 'ipv6' },
+      '80'  => nil,
+    }
+  }
+
+  outputs = {
+    'a hash without a default section' => {
+      'port_80_tcp'  => { 'dports' => [80]  },
+      'port_53_udp'  => { 'dports' => [53]  },
+      'port_443_tcp' => { 'dports' => [443], 'apply_to' => 'ipv6'},
+      'port_514_udp' => { 'dports' => [514] },
+      'port_514_tcp' => { 'dports' => [514] },
+    },
+    'containing a defaults section' => {
+      'port_443_tcp' => { 'dports' => [443], 'apply_to' => 'ipv6'},
+      'port_53_udp'  => { 'dports' => [53],  'apply_to' => 'ipv4'},
+      'port_514_udp' => { 'dports' => [514], 'apply_to' => 'ipv4'},
+      'port_514_tcp' => { 'dports' => [514], 'apply_to' => 'ipv4'},
+      'port_80_tcp'  => { 'dports' => [80],  'apply_to' => 'ipv4'},
+    },
+    'a hash containing an invalid parameter' => {
+      'port_53_tcp'  => { 'dports' => [53],  'apply_to' => 'ipv4', 'param' => 'udp'},
+      'port_443_tcp' => { 'dports' => [443], 'apply_to' => 'ipv6'},
+      'port_80_tcp'  => { 'dports' => [80],  'apply_to' => 'ipv4'},
+    },
+  }
+
+  # inputs.keys.each do |test_name|
+  #   context test_name do
+  #     it {
+  #       is_expected.to run
+  #         .with_params(inputs[test_name])
+  #         .and_return(outputs[test_name])
+  #       }
+  #   end
+  # end
+end


### PR DESCRIPTION
Previously, the iptables::ports hash wouldn't be able to open the same
port on both UDP and TCP. It should work now by specifify `proto` as an
array of strings.

SIMP-4429 #close