### PR TITLE
(SIMP-4009) Ensure idempotency for IPv6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Apr 03 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.3
+- Ensure idempotency when running on IPv6 systems
+
 * Sun Mar 11 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.2
 - Added support for OEL 6 and 7
 - Added Puppet 5 acceptance tests

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.2')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
 end
 
 group :development do
@@ -27,6 +27,7 @@ group :development do
   gem 'puppet-blacksmith'
   gem 'guard-rake'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'pry-doc'
 
   # `listen` is a dependency of `guard`
@@ -37,5 +38,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10')
 end

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,6 +23,13 @@ class iptables::service (
       $_ensure = 'stopped'
     }
 
+    # firewalld must be disabled
+    service{ 'firewalld':
+      ensure => 'stopped',
+      enable => false,
+      before => Service['iptables']
+    }
+
     service { 'iptables':
       ensure     => $_ensure,
       enable     => $enable,
@@ -53,19 +60,8 @@ class iptables::service (
         require  => File['/etc/init.d/ip6tables-retry'],
         provider => 'redhat'
       }
-    }
 
-    # firewalld must be disabled on EL7+
-    case $::operatingsystem {
-      'RedHat','CentOS','OracleLinux': {
-        if $::operatingsystemmajrelease > '6' {
-          service{ 'firewalld':
-            ensure => 'stopped',
-            enable => false,
-            before => Service['iptables']
-          }
-        }
-      }
+      Service['firewalld'] -> Service['ip6tables']
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -53,6 +53,8 @@ describe 'iptables' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_iptables_rule('prevent_ipv6_localhost_spoofing').with_apply_to('ipv6') }
+          it { is_expected.to create_service('firewalld').that_comes_before('Service[iptables]') }
+          it { is_expected.to create_service('firewalld').that_comes_before('Service[ip6tables]') }
         end
 
         context 'with a provided iptables::ports hash' do


### PR DESCRIPTION
Corrected a bug that was causing systems to not be idempotent when IPv6
was enabled.

SIMP-4009 #comment fixed idempotency bug discovered during testing