### PR TITLE
(SIMP-4416) Fix issue with dropped chain

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Wed May 02 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.3
+- Fix issue where a `jump` target went to an empty ruleset and the chain was
+  dropped
+- Retain all native IPTables jump points by default
+- Retain Docker and Kubernetes rules by default
+- Add `==` method for IPTables Rulesets
+
 * Sun Mar 11 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.2
 - Added support for OEL 6 and 7
 - Added Puppet 5 acceptance tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,6 @@
 - Fix issue where a `jump` target went to an empty ruleset and the chain was
   dropped
 - Retain all native IPTables jump points by default
-- Retain Docker and Kubernetes rules by default
 - Add `==` method for IPTables Rulesets
 
 * Sun Mar 11 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.2

--- a/lib/puppet/provider/iptables_optimize/optimize.rb
+++ b/lib/puppet/provider/iptables_optimize/optimize.rb
@@ -75,10 +75,7 @@ Puppet::Type.type(:iptables_optimize).provide(:optimize) do
 
     # We go ahead and do the comparison here because passing the
     # appropriate values around becomes a mess in the log output.
-    #
-    # We need to compare the String versions since the Hashes will contain
-    # unique object references
-    if @ipt_config[:target_config].to_s != @ipt_config[:optimized_config].to_s
+    if @ipt_config[:target_config] != @ipt_config[:optimized_config]
       @ipt_config[:changed] = true
       unless (resource[:optimize] == :true)
         result = :synchronized
@@ -93,7 +90,6 @@ Puppet::Type.type(:iptables_optimize).provide(:optimize) do
   def system_insync?
     optimized_rules = @ipt_config[:optimized_config].report(resource[:ignore])
     running_rules = @ipt_config[:running_config].report(resource[:ignore])
-
 
     # We only care about tables that we're managing!
     (running_rules.keys - optimized_rules.keys).each do |chain|

--- a/lib/puppetx/simp/iptables.rb
+++ b/lib/puppetx/simp/iptables.rb
@@ -323,9 +323,9 @@ module PuppetX
       #
       def preserve_match(regex = [], components = ['chain', 'jump', 'input_interface', 'output_interface'])
 
-	# A standard list of items that are built into iptables, along with the
-	# standard Docker and Kubernetes rules that should always be preserved
-	always_preserve = Regexp.new('^(' + [
+      # A standard list of items that are built into iptables, along with the
+      # standard Docker and Kubernetes rules that should always be preserved
+      always_preserve = Regexp.new('^(' + [
           'ACCEPT',
           'DROP',
           'FORWARD',
@@ -333,9 +333,6 @@ module PuppetX
           'OUTPUT',
           '(NF)?LOG',
           '(PRE|POST)ROUTING',
-          'DOCKER',
-          'docker',
-          'KUBE',
           'REDIRECT',
           'MASQ',
           'MASQUERADE',

--- a/lib/puppetx/simp/iptables.rb
+++ b/lib/puppetx/simp/iptables.rb
@@ -47,6 +47,12 @@ module PuppetX
         prune_chains!
       end
 
+      # A comparator for two rulesets
+      def ==(to_cmp)
+        tables == to_cmp.tables &&
+          report == to_cmp.report
+      end
+
       # Sort a list of rules into the same order that `iptables-save` uses on
       # output
       #
@@ -94,7 +100,6 @@ module PuppetX
       #   The IPTables object to be merged
       #
       def merge!(iptables_obj)
-
         iptables_obj.tables.each do |table|
           add_chains(table, iptables_obj.chains(table))
           prepend_rules(table, iptables_obj.rules(table))
@@ -169,8 +174,9 @@ module PuppetX
           @tables[key][:rules]
         }.
         flatten.map { |rule|
-          rule.chain
-        }.uniq
+          new_rule = [rule.chain]
+          new_rule << rule.jump if rule.jump
+        }.flatten.uniq
 
         tables.each do |table|
           chains_to_keep = []
@@ -317,6 +323,45 @@ module PuppetX
       #
       def preserve_match(regex = [], components = ['chain', 'jump', 'input_interface', 'output_interface'])
 
+	# A standard list of items that are built into iptables, along with the
+	# standard Docker and Kubernetes rules that should always be preserved
+	always_preserve = Regexp.new('^(' + [
+          'ACCEPT',
+          'DROP',
+          'FORWARD',
+          'INPUT',
+          'OUTPUT',
+          '(NF)?LOG',
+          '(PRE|POST)ROUTING',
+          'DOCKER',
+          'docker',
+          'KUBE',
+          'REDIRECT',
+          'MASQ',
+          'MASQUERADE',
+          'RETURN',
+          'MARK',
+          'NOTRACK',
+          'SET',
+          '(D|S)NAT',
+          '(D|S)NPT',
+          'AUDIT',
+          'CONN(SEC)?MARK',
+          'HMARK',
+          'LED',
+          'RATEEST',
+          'REJECT',
+          'RPFILTER',
+          'SECMARK',
+          'SYNPROXY',
+          'TCP(MSS|OPTSTRIP)',
+          'TEE',
+          'TOS',
+        ].join('|') + ')$')
+
+        _regex = Array(regex).dup
+        _regex << always_preserve
+
         result = PuppetX::SIMP::IPTables.new('')
 
         @tables.each_key do |table|
@@ -325,9 +370,13 @@ module PuppetX
           result.add_chains(table, chains(table))
 
           rules(table).each do |rule|
-            Array(regex).each do |cmp|
+            # Ignore all rules dropped by SIMP
+            next if (rule.rule_hash['comment'] && rule.rule_hash['comment'][:value].start_with?('SIMP:'))
+
+            Array(_regex).each do |cmp|
               Array(components).each do |component|
                 val = rule.send(component)
+
                 if cmp.match(val)
                   result.prepend_rules(table, rule)
                 end

--- a/lib/puppetx/simp/iptables.rb
+++ b/lib/puppetx/simp/iptables.rb
@@ -323,8 +323,7 @@ module PuppetX
       #
       def preserve_match(regex = [], components = ['chain', 'jump', 'input_interface', 'output_interface'])
 
-      # A standard list of items that are built into iptables, along with the
-      # standard Docker and Kubernetes rules that should always be preserved
+      # A standard list of items that are built into iptables
       always_preserve = Regexp.new('^(' + [
           'ACCEPT',
           'DROP',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fix issue where a `jump` target went to an empty ruleset and the chain
  was dropped
- Retain all native IPTables jump points by default
- Retain Docker and Kubernetes rules by default
- Add `==` method for IPTables Rulesets

SIMP-4416 #comment IPTables fix due to bug exposed by kubernetes