### PR TITLE
(SIMP-5856) Allow fw rules above LOCAL-INPUT jump

### DIFF
--- a/manifests/rules/base.pp
+++ b/manifests/rules/base.pp
@@ -31,7 +31,7 @@ class iptables::rules::base (
 
   iptables_rule { 'global':
     table    => 'filter',
-    first    => true,
+    first    => false,
     absolute => true,
     header   => false,
     content  => '-A INPUT -j LOCAL-INPUT


### PR DESCRIPTION
The FORWARD and INPUT chains in the filter table include a jump to the
LOCAL-INPUT chain. This jump occurs first, which is problematic for
adding custom rules to those chains. That default rule should be placed
last, so that other custom rules can be processed before the default
behavior of jumping to the LOCAL-INPUT chain for further processing.