### PR TITLE
Wrong parameter name on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ rules.
 #open TCP port 443 (HTTPS) and a custom 8443 from any IP Address
 
 iptables::listen::tcp_stateful { 'webserver':
-  client_nets => ['any'],
-  dports => ['443','8443']
+  trusted_nets => ['any'],
+  dports => [ 443 , 8443 ]
 }
 
 #open UDP port 53 (DNS) from two specific IP addresses
 
 iptables::listen::udp {'DNS':
-  client_nets => ['192.168.56.55','192.168.56.147'],
-  dports      => ['53']
+  trusted_nets => ['192.168.56.55','192.168.56.147'],
+  dports      => [ 53 ]
 }
 
 #Allow a specific machine full access to this node
@@ -129,7 +129,7 @@ iptables::add_all_listen { 'Central Management':
 
 #Allow a range of ports to be accessible from a specific IP
 iptables::listen::tcp_stateful { 'myapp':
-  client_nets => ['10.10.45.100'],
+  trusted_nets => ['10.10.45.100'],
   dports => ['1024:60000']
 }
 


### PR DESCRIPTION
I had run into this a few months back and forgot to PR this fix, I just ran into this again... so here is a shameless documentation PR :)

2 Different errors/typos:
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation 

1st tpo
Error: Error while evaluating a Resource Statement, Iptables::Listen::Tcp_stateful[crowd]:
  has no parameter named 'client_nets'

Wrong value 'client_nets'
Correct value 'trusted_nets'

  parameter 'dports' variant 0 expects a Simplib::Port = Variant[Simplib::Port::Random = Integer[0, 0], Simplib::Port::System = Integer[1, 1024], Simplib::Port::User = Variant[Integer[1025, 49151], Integer[49153, 65534]], Simplib::Port::Dynamic = Integer[49152, 65535]] value, got Tuple

2nd typo is for the single quotes around port, this is not needed unless you are defining a port range (basically due to the colon ":")