### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.7
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Mon Jan 21 2019 Miguel Cruz <mcruz@metrostarsystems.com> - 6.1.7
 - Fix typo in documentation
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The `ip6tables_optimize` type has the exact same parameters but affects
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Acceptance tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-iptables