### PR TITLE
(SIMP-6252) Replace Puppet 3 slice_array

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Mon Mar 25 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.8
+- Fixed bug in which port ranges specified by
+  iptables::listen::tcp_stateful::dports or iptables::listen::udp::dports
+  could be erroneously split over multiple iptables rules
+- Replaced deprecated simplib Puppet 3 function slice_array with
+  iptables::slice_ports
+
 * Mon Mar 25 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 6.1.8
 - Updated puppet template scope API from 3 to newer
 

--- a/lib/puppet/functions/iptables/slice_ports.rb
+++ b/lib/puppet/functions/iptables/slice_ports.rb
@@ -1,0 +1,43 @@
+# Split a stringified Iptables::DestPort into an Array that contain groupings
+# of `max_length` size.
+Puppet::Functions.create_function(:'iptables::slice_ports') do
+
+  # @param input One or more ports or port ranges, all represented
+  #   as strings.
+  #
+  # @param max_length The maximum length of each group.
+  #
+  # @return [Array[Array[String]]]]
+  dispatch :slice_ports do
+    required_param 'Variant[String,Array[String]]', :input
+    required_param 'Integer[1]',                    :max_length
+  end
+
+  def slice_ports(input, max_length)
+    to_slice = Array(input).flatten
+    split_char = ':'
+
+    if max_length == 1 && to_slice.any? { |entry| entry.include?(split_char) }
+      err_msg = 'iptables::slice_port: max_length must be >=2 when input has a port range'
+      fail(err_msg)
+    end
+
+    retval = []
+    count = 0
+    group = []
+    to_slice.each do |entry|
+      num_values = entry.include?(split_char) ? 2 : 1
+      if count + num_values <= max_length
+        count += num_values
+        group << entry
+      else
+        retval << group
+        count = num_values
+        group = [ entry ]
+      end
+    end
+    retval << group unless group.empty?
+
+    retval
+  end
+end

--- a/spec/defines/listen/tcp_stateful_spec.rb
+++ b/spec/defines/listen/tcp_stateful_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper.rb'
 
 describe "iptables::listen::tcp_stateful", :type => :define do
   context  'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts
+          os_facts
         end
 
         context "with trusted_nets in IPv4 CIDR format" do
@@ -15,6 +15,10 @@ describe "iptables::listen::tcp_stateful", :type => :define do
             :dports      => [1234, '234:567']
           }}
           it { is_expected.to create_iptables__listen__tcp_stateful('allow_tcp_1234').with_dports(params[:dports]) }
+          it do
+            expected = "-m state --state NEW -m tcp -p tcp -s 10.0.2.0/24 -m multiport --dports 1234,234:567 -j ACCEPT\n"
+            is_expected.to create_iptables_rule('tcp_allow_tcp_1234').with_content(expected)
+          end
         end
 
         context "with trusted_nets in IPv6 CIDR format" do
@@ -42,6 +46,43 @@ describe "iptables::listen::tcp_stateful", :type => :define do
           # does it create the correct rule?
           it {
             is_expected.to create_iptables_rule('tcp_allow_tcp_more_than_10_ports').with_content(/ --dports 101,102,103,104,105,106,107,108,109,110,111 -j ACCEPT/) }
+        end
+
+        context 'with more than 15 individual ports' do
+          let( :title  ){ 'allow_tcp_more_than_15_ports' }
+          let( :params ){{
+            :trusted_nets => ['10.0.2.0/24'],
+            :dports      => (101..121).to_a
+          }}
+
+          it { is_expected.to create_iptables__listen__tcp_stateful('allow_tcp_more_than_15_ports').with_dports((101..121).to_a)
+          }
+
+          it do
+            expected = <<-EOM
+-m state --state NEW -m tcp -p tcp -s 10.0.2.0/24 -m multiport --dports 101,102,103,104,105,106,107,108,109,110,111,112,113,114,115 -j ACCEPT
+-m state --state NEW -m tcp -p tcp -s 10.0.2.0/24 -m multiport --dports 116,117,118,119,120,121 -j ACCEPT
+            EOM
+            is_expected.to create_iptables_rule('tcp_allow_tcp_more_than_15_ports').with_content(expected)
+          end
+        end
+
+        context 'single port ranges' do
+          let( :title  ){ 'allow_port_range' }
+          let( :params ){{
+            :trusted_nets => ['10.0.2.0/24'],
+            :dports      => '150:300'
+          }}
+
+          it { is_expected.to create_iptables__listen__tcp_stateful('allow_port_range').with_dports('150:300')
+          }
+
+          it do
+            expected = <<-EOM
+-m state --state NEW -m tcp -p tcp -s 10.0.2.0/24 -m multiport --dports 150:300 -j ACCEPT
+            EOM
+            is_expected.to create_iptables_rule('tcp_allow_port_range').with_content(expected)
+          end
         end
       end
     end

--- a/spec/defines/listen/udp_spec.rb
+++ b/spec/defines/listen/udp_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper.rb'
 
 describe "iptables::listen::udp", :type => :define do
   context  'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts
+          os_facts
         end
 
         describe "with IPv4 trusted_nets" do
@@ -15,9 +15,13 @@ describe "iptables::listen::udp", :type => :define do
             :dports       => [1234,'9999:20000']
           }}
           it { is_expected.to create_iptables__listen__udp("allow_udp_range").with_dports(params[:dports]) }
+          it do
+            expected = "-m state --state NEW -p udp -s 10.0.2.0 -m multiport --dports 1234,9999:20000 -j ACCEPT\n"
+            is_expected.to create_iptables_rule('udp_allow_udp_range').with_content(expected)
+          end
         end
 
-        describe "with IPv4 trusted_netsi in CIDR notation" do
+        describe "with IPv4 trusted_nets in CIDR notation" do
           let( :title  ){ 'allow_udp_1234' }
           let( :params ){{
             :trusted_nets => ['10.0.2.0/24'],
@@ -50,6 +54,42 @@ describe "iptables::listen::udp", :type => :define do
           it{
             is_expected.to create_iptables_rule('udp_allow_udp_1234')
           }
+        end
+
+        describe 'with more than 15 individual ports' do
+          let( :title  ){ 'allow_udp_more_than_15_ports' }
+          let( :params ){{
+            :trusted_nets => ['10.0.2.0/24'],
+            :dports      => (101..121).to_a
+          }}
+
+          it { is_expected.to create_iptables__listen__udp('allow_udp_more_than_15_ports').with_dports((101..121).to_a)
+          }
+
+          it do
+            expected = <<-EOM
+-m state --state NEW -p udp -s 10.0.2.0/24 -m multiport --dports 101,102,103,104,105,106,107,108,109,110,111,112,113,114,115 -j ACCEPT
+-m state --state NEW -p udp -s 10.0.2.0/24 -m multiport --dports 116,117,118,119,120,121 -j ACCEPT
+            EOM
+            is_expected.to create_iptables_rule('udp_allow_udp_more_than_15_ports').with_content(expected)
+          end
+        end
+
+        describe 'single port ranges' do
+          let( :title  ){ 'allow_port_range' }
+          let( :params ){{
+            :trusted_nets => ['10.0.2.0/24'],
+            :dports      => '150:300'
+          }}
+
+          it { is_expected.to create_iptables__listen__udp('allow_port_range').with_dports('150:300') }
+
+          it do
+            expected = <<-EOM
+-m state --state NEW -p udp -s 10.0.2.0/24 -m multiport --dports 150:300 -j ACCEPT
+            EOM
+            is_expected.to create_iptables_rule('udp_allow_port_range').with_content(expected)
+          end
         end
       end
     end

--- a/spec/functions/iptables/slice_ports_spec.rb
+++ b/spec/functions/iptables/slice_ports_spec.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'iptables::slice_ports' do
+  context 'when single port' do
+    let(:input) { '0' }
+    it 'should return a single array with input' do
+      is_expected.to run.with_params(input, 15).and_return([[input]])
+    end
+  end
+
+  context 'when array of single ports' do
+    let(:input) { ['1', '2', '3', '4', '5', '6'] }
+
+    context 'when max_length is < input array size' do
+      it 'should return multiple sub-arrays' do
+        expected = [['1','2','3','4'], ['5','6']]
+        is_expected.to run.with_params(input, 4).and_return(expected)
+      end
+    end
+
+    context 'when max_length is >= input array size' do
+      it 'should return one sub-array' do
+        is_expected.to run.with_params(input, input.size).and_return([input])
+      end
+    end
+  end
+
+  context 'when single range' do
+    let(:input) { '59:300' }
+
+    it 'should return one sub-array if max_length >= 2' do
+      is_expected.to run.with_params(input, 2).and_return([[input]])
+    end
+  end
+
+  context 'when array of ranges' do
+    let(:input) { ['10:20', '110:120', '210:220'] }
+
+    it 'should treat each range as 2 entries' do
+      expected = [['10:20'], ['110:120'], ['210:220']]
+      is_expected.to run.with_params(input, 2).and_return(expected)
+
+      expected = [['10:20','110:120'], ['210:220']]
+      is_expected.to run.with_params(input, 4).and_return(expected)
+    end
+
+    it 'should not split any range into sub-arrays' do
+      expected = [['10:20'], ['110:120'], ['210:220']]
+      is_expected.to run.with_params(input, 3).and_return(expected)
+    end
+  end
+
+  context 'when mixed array of individual ports and ranges ' do
+    let(:input) { ['1', '2', '3:10', '14', '15', '20:120' ] }
+
+    it 'should treat each range a 2 entries' do
+      expected = [['1', '2','3:10'], ['14', '15', '20:120']]
+      is_expected.to run.with_params(input, 4).and_return(expected)
+    end
+
+    it 'should not split any range into sub-arrays' do
+      expected = [['1', '2'], ['3:10', '14'], ['15', '20:120']]
+      is_expected.to run.with_params(input, 3).and_return(expected)
+    end
+  end
+
+  context 'failures' do
+    let(:input) { '59:300' }
+
+    it 'should fail if max_length is 1 and input contains a port range' do
+      # Where this function is used, max_length = 15, so not going
+      # to worry about fixing this edge case for now.
+      is_expected.to run.with_params(input, 1).and_raise_error(/max_length must be >=2 when input has a port range/)
+    end
+  end
+
+end

--- a/templates/allow_tcp_udp_services.erb
+++ b/templates/allow_tcp_udp_services.erb
@@ -7,7 +7,7 @@ allow_all = (trusted_nets.include?('any') || trusted_nets.include?('ALL'))
 dports = Array(@dports).flatten.map(&:to_s).uniq.sort
 all_dports = (dports.include?('any') || dports.include?('ALL'))
 
-port_slices = scope.call_function('slice_array',[dports,max_multiport_length,':'])
+port_slices = scope.call_function('iptables::slice_ports', [dports, max_multiport_length])
 
 output_base = "-m state --state NEW"
 if @_protocol == 'tcp'


### PR DESCRIPTION
- Fixed bug in which port ranges specified by
  iptables::listen::tcp_stateful::dports or
  iptables::listen::udp::dports could be erroneously split
  over multiple iptables rules
- Replaced deprecated simplib Puppet 3 function slice_array with
  iptables::slice_ports

SIMP-6252 #comment pupmod-simp-iptables
SIMP-6322 #close