### PR TITLE
(SIMP-6242) Add rule to drop 127.0.0.0/8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Apr 01 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.9
+- Added rule to drop 127.0.0.0/8 addresses as defined in
+  RFC 1122 - Section: 3.2.1.3(g).
+
 * Mon Mar 25 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.8
 - Fixed bug in which port ranges specified by
   iptables::listen::tcp_stateful::dports or iptables::listen::udp::dports

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Apr 01 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.9
+* Mon Apr 01 2019 Jim Anderson <thesemicolons@protonmail.com> - 6.1.8
 - Added rule to drop 127.0.0.0/8 addresses as defined in
   RFC 1122 - Section: 3.2.1.3(g).
 

--- a/manifests/rules/base.pp
+++ b/manifests/rules/base.pp
@@ -14,7 +14,7 @@
 #
 #   * This is enabled by default for RFC 1122 compliance
 #
-# @see https://tools.ietf.org/html/rfc1122#page-42 RFC 1122 Section 3.2.2.6
+#   @see https://tools.ietf.org/html/rfc1122#page-42 RFC 1122 Section 3.2.2.6
 #
 # @param drop_broadcast
 #   Drop all broadcast traffic to this host
@@ -22,7 +22,7 @@
 # @param drop_loopback
 #   Drop all loopback traffic to this host
 #
-# @see https://tools.ietf.org/html/rfc1122#page-31 RFC 1122 Section 3.2.1.3(g)
+#   @see https://tools.ietf.org/html/rfc1122#page-31 RFC 1122 Section 3.2.1.3(g)
 #
 # @param drop_multicast
 #   Drop all multicast traffic to this host

--- a/manifests/rules/base.pp
+++ b/manifests/rules/base.pp
@@ -22,7 +22,7 @@
 # @param drop_loopback
 #   Drop all loopback traffic to this host
 #
-# @see https://tools.ietf.org/html/rfc1122#page-42 RFC 1122 Section 3.2.1.3(g)
+# @see https://tools.ietf.org/html/rfc1122#page-31 RFC 1122 Section 3.2.1.3(g)
 #
 # @param drop_multicast
 #   Drop all multicast traffic to this host

--- a/manifests/rules/base.pp
+++ b/manifests/rules/base.pp
@@ -72,6 +72,14 @@ class iptables::rules::base (
     }
   }
 
+# Drop addresses defined in RFC 1122 - Section: 3.2.1.3(g).
+  iptables_rule { 'drop_loopback':
+    table    => 'filter',
+    order    => '22',
+    content  => '-s 127.0.0.0/8 -j DROP',
+    apply_to => 'ipv4'
+  }
+
   if $drop_broadcast {
     iptables_rule { 'drop_broadcast':
       table    => 'filter',

--- a/manifests/rules/base.pp
+++ b/manifests/rules/base.pp
@@ -19,12 +19,18 @@
 # @param drop_broadcast
 #   Drop all broadcast traffic to this host
 #
+# @param drop_loopback
+#   Drop all loopback traffic to this host
+#
+# @see https://tools.ietf.org/html/rfc1122#page-42 RFC 1122 Section 3.2.1.3(g)
+#
 # @param drop_multicast
 #   Drop all multicast traffic to this host
 #
 class iptables::rules::base (
   Boolean $allow_ping     = true,
   Boolean $drop_broadcast = true,
+  Boolean $drop_loopback  = true,
   Boolean $drop_multicast = true
 ){
   assert_private()
@@ -73,11 +79,13 @@ class iptables::rules::base (
   }
 
 # Drop addresses defined in RFC 1122 - Section: 3.2.1.3(g).
-  iptables_rule { 'drop_loopback':
-    table    => 'filter',
-    order    => '22',
-    content  => '-s 127.0.0.0/8 -j DROP',
-    apply_to => 'ipv4'
+  if $drop_loopback {
+    iptables_rule { 'drop_loopback':
+      table    => 'filter',
+      order    => '22',
+      content  => '-s 127.0.0.0/8 -j DROP',
+      apply_to => 'ipv4'
+    }
   }
 
   if $drop_broadcast {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.1.9",
+  "version": "6.1.8",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.1.8",
+  "version": "6.1.9",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",


### PR DESCRIPTION
Added rule to drop 127.0.0.0/8 addresses as defined in
RFC 1122 - Section: 3.2.1.3(g). This will exclude 127.0.0.1 as it is
allowed in an earlier rule.