### PR TITLE
(SIMP-4429) Allow 'proto' in iptables::ports to be an array

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 10 2019 Steven Pritchard <steven.pritchard@onyxpoint.com> - 6.2.1
+- Allow 'proto' in iptables::ports to be an array
+
 * Mon Apr 08 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.0
 - Added 'iptables_default_policy' for modifying the default policy of the
   'filter' table on either IPv4 or IPv6.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -67,6 +67,8 @@ describe 'iptables' do
             it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with({ :apply_to => 'auto'}) }
             it { is_expected.to create_iptables__listen__udp('port_53').with({ :apply_to => 'auto'}) }
             it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with({ :apply_to => 'ipv6'}) }
+            it { is_expected.to create_iptables__listen__udp('port_88').with({ :apply_to => 'auto'}) }
+            it { is_expected.to create_iptables__listen__tcp_stateful('port_88').with({ :apply_to => 'auto'}) }
           end
           context 'a hash containing an invalid parameter' do
             let(:hieradata){ 'iptables__ports_bad_param' }

--- a/spec/defines/ports_spec.rb
+++ b/spec/defines/ports_spec.rb
@@ -17,12 +17,17 @@ describe "iptables::ports", :type => :define do
             },
             '443' => {
               'apply_to' => 'ipv6'
-            }
+            },
+            '88' => {
+              'proto' => ['udp','tcp']
+            },
           }
         }}
         it { is_expected.to create_iptables__listen__tcp_stateful('port_80').with(apply_to: 'auto') }
         it { is_expected.to create_iptables__listen__udp('port_53').with(apply_to: 'auto') }
         it { is_expected.to create_iptables__listen__tcp_stateful('port_443').with(apply_to: 'ipv6') }
+        it { is_expected.to create_iptables__listen__udp('port_88').with({ :apply_to => 'auto'}) }
+        it { is_expected.to create_iptables__listen__tcp_stateful('port_88').with({ :apply_to => 'auto'}) }
       end
 
       context 'containing a defaults section' do

--- a/spec/fixtures/hieradata/iptables__ports_no_default.yaml
+++ b/spec/fixtures/hieradata/iptables__ports_no_default.yaml
@@ -5,3 +5,7 @@ iptables::ports:
     proto: udp
   443:
     apply_to: ipv6
+  88:
+    proto:
+      - udp
+      - tcp


### PR DESCRIPTION
- Allow 'proto' in iptables::ports to be an array
- Bump version to 6.2.1

SIMP-4429 #close