### PR TITLE
(SIMP-7538) Fix firewall service name strings

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,7 +7,7 @@ fixtures:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld
-      ref: v4.2.2
+      ref: v4.2.3
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,7 +7,7 @@ fixtures:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld
-      ref: v4.2.3
+      ref: v4.2.4
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,7 +7,7 @@ fixtures:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld
-      ref: v4.1.0
+      ref: v4.2.2
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,21 @@
-gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
+gem_sources   = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
   gem 'puppet', ENV.fetch('PUPPET_VERSION', '~> 5.5')
+
   gem 'rspec'
   gem 'rspec-puppet'
+  gem 'puppet-strings'
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
-  gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 2.4.0', '< 3.0.0'] )
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.9', '< 6.0'])
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.2')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.6')
 end
 
 group :development do
@@ -25,5 +26,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.17.0', '< 2.0.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.12')
 end

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,7 +6,7 @@
 **Classes**
 
 * [`iptables`](#iptables): Add management of iptables with default rule optimization and a failsafe fallback mode  This class will detect conflicts with the SIMP option
-* [`iptables::firewalld::shim`](#iptablesfirewalldshim): These items mimic components in the actual `firewalld` module but set them to safer defaults per the usual "authoritative control" idea of SI
+* [`iptables::firewalld::shim`](#iptablesfirewalldshim): This is a `firewalld` profile that sets "safe" defaults as is usual in SIMP modules.  If you want to override any element not present in the 
 * [`iptables::install`](#iptablesinstall): **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**  Install the IPTables and IP6Tables compo
 * [`iptables::rules::base`](#iptablesrulesbase): **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**  Set up the basic iptables rules pertinen
 * [`iptables::rules::default_drop`](#iptablesrulesdefault_drop): **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**  Manage the default policy settings of th
@@ -191,12 +191,16 @@ Default value: `undef`
 
 ### iptables::firewalld::shim
 
-These items mimic components in the actual `firewalld` module but set them to
-safer defaults per the usual "authoritative control" idea of SIMP.
+This is a `firewalld` profile that sets "safe" defaults as is usual in SIMP
+modules.
 
-Since the `firewalld` module is designed to be Hiera-driven, this was more
-understandable and safer than encapsulating the entire module in the
-`iptables` module directly.
+If you want to override any element not present in the `firewalld` class
+resource below then you should use Hiera directly on the `firewalld` class.
+
+## Class Resources
+
+The following class resources are used in this code:
+  - firewalld
 
 #### Parameters
 
@@ -259,6 +263,16 @@ What types of logs to process for denied packets.
 
 Default value: 'unicast'
 
+##### `firewall_backend`
+
+Data type: `Enum['iptables','nftables']`
+
+Allows you to set the backend that firewalld will use.
+
+* Currently set to 'iptables' due to bugs in nftables
+
+Default value: 'iptables'
+
 ##### `enable_tidy`
 
 Data type: `Boolean`
@@ -300,7 +314,7 @@ Default value: 10
 
 Data type: `Array[Optional[String[1]]]`
 
-
+The network interfaces to which the underlying 99_simp zone should apply
 
 Default value: []
 
@@ -308,7 +322,7 @@ Default value: []
 
 Data type: `Enum['default', 'ACCEPT', 'REJECT', 'DROP']`
 
-
+The default target for the 99_simp zone
 
 Default value: 'DROP'
 

--- a/manifests/firewalld/rule.pp
+++ b/manifests/firewalld/rule.pp
@@ -50,6 +50,9 @@ define iptables::firewalld::rule (
 ) {
   simplib::assert_optional_dependency($module_name, 'puppet/firewalld')
 
+  # Firewalld does not handle some items well in filenames
+  $safe_name = regsubst($name, /\./, '_', 'G')
+
   if $protocol == 'icmp' {
     $_dports = undef
     $_icmp_block = Array($icmp_blocks)
@@ -74,7 +77,7 @@ define iptables::firewalld::rule (
         }
       }
 
-      firewalld::custom_service { "simp_${name}":
+      firewalld::custom_service { "simp_${safe_name}":
         short       => "simp_${name}",
         description => "SIMP ${name}",
         port        => $_dports,
@@ -101,7 +104,7 @@ define iptables::firewalld::rule (
   # It only makes sense to create this if we have been passed some ports to
   # bind it to.
   if $_dports and $_allow_from_all {
-    firewalld_service { "simp_${name}":
+    firewalld_service { "simp_${safe_name}":
       zone    => '99_simp',
       require => Service['firewalld']
     }

--- a/manifests/firewalld/rule.pp
+++ b/manifests/firewalld/rule.pp
@@ -50,10 +50,9 @@ define iptables::firewalld::rule (
 ) {
   simplib::assert_optional_dependency($module_name, 'puppet/firewalld')
 
-  # Replace this with the line below it when
-  # https://github.com/simp/pupmod-simp-iptables/pull/74 is merged and released
-
   $_safe_name = regsubst($name, '[^\w-]', '_', 'G')
+
+  # Saving this as a reference for when we split this off into its own module
   #$_safe_name = firewalld::safe_filename($name)
 
   if $protocol == 'icmp' {

--- a/manifests/firewalld/rule.pp
+++ b/manifests/firewalld/rule.pp
@@ -50,8 +50,11 @@ define iptables::firewalld::rule (
 ) {
   simplib::assert_optional_dependency($module_name, 'puppet/firewalld')
 
-  # Firewalld does not handle some items well in filenames
-  $safe_name = regsubst($name, /\./, '_', 'G')
+  # Replace this with the line below it when
+  # https://github.com/simp/pupmod-simp-iptables/pull/74 is merged and released
+
+  $_safe_name = regsubst($name, '[^\w-]', '_', 'G')
+  #$_safe_name = firewalld::safe_filename($name)
 
   if $protocol == 'icmp' {
     $_dports = undef
@@ -77,7 +80,7 @@ define iptables::firewalld::rule (
         }
       }
 
-      firewalld::custom_service { "simp_${safe_name}":
+      firewalld::custom_service { "simp_${_safe_name}":
         short       => "simp_${name}",
         description => "SIMP ${name}",
         port        => $_dports,
@@ -104,7 +107,7 @@ define iptables::firewalld::rule (
   # It only makes sense to create this if we have been passed some ports to
   # bind it to.
   if $_dports and $_allow_from_all {
-    firewalld_service { "simp_${safe_name}":
+    firewalld_service { "simp_${_safe_name}":
       zone    => '99_simp',
       require => Service['firewalld']
     }
@@ -128,7 +131,7 @@ define iptables::firewalld::rule (
 
         $_msg_string = join($_tmp_nets_hash['unknown'].keys, ', ')
 
-        notify { "${module_name}::firewalld::rule[$name] - hostname warning":
+        notify { "${module_name}::firewalld::rule[$_safe_name] - hostname warning":
           message  => "Firewalld cannot handle hostnames and the following were found in 'trusted_nets': '${_msg_string}'",
           withpath => true,
           loglevel => 'warning'
@@ -210,7 +213,7 @@ define iptables::firewalld::rule (
                 join([
                   'simp',
                   $order,
-                  $name,
+                  $_safe_name,
                   $_ipset_name
                 ], '_'),
               '_+', '_', 'G')
@@ -231,7 +234,7 @@ define iptables::firewalld::rule (
               # bind to. This probably means that we were called in a way to
               # allow all traffic to a specific IP address.
               if $_dports {
-                $_rich_rule_svc = "simp_${name}"
+                $_rich_rule_svc = "simp_${_safe_name}"
               }
               else {
                 $_rich_rule_svc = undef

--- a/manifests/firewalld/shim.pp
+++ b/manifests/firewalld/shim.pp
@@ -41,6 +41,11 @@
 #
 #   @see LogDenied in firewalld.conf(5)
 #
+# @param firewall_backend
+#   Allows you to set the backend that firewalld will use.
+#
+#   * Currently set to 'iptables' due to bugs in nftables
+#
 # @param enable_tidy
 #   Enable the ``Tidy`` resources that help keep the system clean from cruft
 #
@@ -54,15 +59,22 @@
 #   Number of **minutes** to consider a configuration file 'stale' for the
 #   purposes of tidying.
 #
+# @param simp_zone_interfaces
+#   The network interfaces to which the underlying 99_simp zone should apply
+#
+# @param simp_zone_target
+#   The default target for the 99_simp zone
+#
 class iptables::firewalld::shim (
-  Boolean                                              $enable          = true,
-  Boolean                                              $complete_reload = false,
-  Boolean                                              $lockdown        = true,
-  String[1]                                            $default_zone    = '99_simp',
-  Enum['off', 'all','unicast','broadcast','multicast'] $log_denied      = 'unicast',
-  Boolean                                              $enable_tidy     = true,
+  Boolean                                              $enable               = true,
+  Boolean                                              $complete_reload      = false,
+  Boolean                                              $lockdown             = true,
+  String[1]                                            $default_zone         = '99_simp',
+  Enum['off', 'all','unicast','broadcast','multicast'] $log_denied           = 'unicast',
+  Enum['iptables','nftables']                          $firewall_backend     = 'iptables',
+  Boolean                                              $enable_tidy          = true,
   # lint:ignore:2sp_soft_tabs
-  Array[Stdlib::Absolutepath]                          $tidy_dirs       = [
+  Array[Stdlib::Absolutepath]                          $tidy_dirs            = [
                                                                                  '/etc/firewalld/icmptypes',
                                                                                  '/etc/firewalld/ipsets',
                                                                                  '/etc/firewalld/services'
@@ -82,9 +94,10 @@ class iptables::firewalld::shim (
     $_lockdown_xlat = $lockdown ? { true => 'yes', default => 'no' }
 
     class { 'firewalld':
-      lockdown     => $_lockdown_xlat,
-      default_zone => $default_zone,
-      log_denied   => $log_denied
+      lockdown         => $_lockdown_xlat,
+      default_zone     => $default_zone,
+      log_denied       => $log_denied,
+      firewall_backend => $firewall_backend
     }
 
     unless $complete_reload {

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
     "optional_dependencies": [
       {
         "name": "puppet/firewalld",
-        "version_requirement": ">= 4.2.2 < 5.0.0"
+        "version_requirement": ">= 4.2.3 < 5.0.0"
       }
     ]
   }

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
     "optional_dependencies": [
       {
         "name": "puppet/firewalld",
-        "version_requirement": ">= 4.1.0 < 5.0.0"
+        "version_requirement": ">= 4.2.2 < 5.0.0"
       }
     ]
   }

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -11,7 +11,7 @@ HOSTS:
       - server7
       - default
     platform: el-7-x86_64
-    box: onyxpoint/oel-7-x86_64
+    box: generic/oracle7
     hypervisor: <%= hypervisor %>
 
   oel6:
@@ -21,11 +21,11 @@ HOSTS:
     box: onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
 
-  oel6:
+  oel8:
     roles:
       - server8
     platform: el-8-x86_64
-    box: onyxpoint/oel-8-x86_64
+    box: generic/oracle8
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/acceptance/suites/firewalld/00_default_spec.rb
+++ b/spec/acceptance/suites/firewalld/00_default_spec.rb
@@ -15,7 +15,7 @@ hosts.each do |host|
         # Ironically, if iptables applies correctly, its default settings will
         # deny Vagrant access via SSH.  So, it is neccessary for beaker to also
         # define a rule that permit SSH access from the standard Vagrant subnets:
-        iptables::listen::tcp_stateful { 'allow_sshd':
+        iptables::listen::tcp_stateful { 'allow_sshd_0.0.0.0':
           trusted_nets => ['0.0.0.0/0'],
           dports       => 22,
         }
@@ -37,9 +37,9 @@ hosts.each do |host|
           expect(default_zone).to eq('99_simp')
         end
 
-        it 'should have the "simp_tcp_allow_sshd" service in the "99_simp" zone' do
+        it 'should have the "simp_tcp_allow_sshd_0_0_0_0" service in the "99_simp" zone' do
           simp_services = on(host, 'firewall-cmd --list-services --zone=99_simp').output.strip.split(/\s+/)
-          expect(simp_services).to include('simp_tcp_allow_sshd')
+          expect(simp_services).to include('simp_tcp_allow_sshd_0_0_0_0')
         end
       else
         it 'should not be running firewalld' do
@@ -75,9 +75,9 @@ hosts.each do |host|
           apply_manifest_on(host, manifest, :catch_changes => true)
         end
 
-        it 'should have the "simp_tcp_allow_sshd" service in the "99_simp" zone' do
+        it 'should have the "simp_tcp_allow_sshd_0_0_0_0" service in the "99_simp" zone' do
           simp_services = on(host, 'firewall-cmd --list-services --zone=99_simp').output.strip.split(/\s+/)
-          expect(simp_services).to include('simp_tcp_allow_sshd')
+          expect(simp_services).to include('simp_tcp_allow_sshd_0_0_0_0')
         end
 
         it 'should have an appropriate ruleset configured' do
@@ -138,9 +138,9 @@ hosts.each do |host|
           apply_manifest_on(host, manifest, :catch_changes => true)
         end
 
-        it 'should have the "simp_tcp_allow_sshd" service in the "99_simp" zone' do
+        it 'should have the "simp_tcp_allow_sshd_0_0_0_0" service in the "99_simp" zone' do
           simp_services = on(host, 'firewall-cmd --list-services --zone=99_simp').output.strip.split(/\s+/)
-          expect(simp_services).to include('simp_tcp_allow_sshd')
+          expect(simp_services).to include('simp_tcp_allow_sshd_0_0_0_0')
         end
 
         it 'should have an appropriate ruleset configured' do


### PR DESCRIPTION
* Bump upstream firewalld to 4.2.2 for backend selection support
* Set the default backend to 'iptables' to work around nftables bugs
* Ensure that firewalld service names do not contain a '.' character
* Fix missing entries in REFERENCE.md

SIMP-7538 #close