### PR TITLE
(SIMP-8328) Fix iptables rule address normalization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Aug 18 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.5.1
+- Ensure that all addresses are normalized when rules are processed
+- Remove nested looped rule normalization of addresses since it is no longer
+  required
+- Fix normalize_addresses() so that it simply grabs the netmask if present and
+  slaps on the appropriate one if not
+
 * Wed Jun 10 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.5.0
 - Removed the experimental firewalld support
 - Hooked the module into the new simp/simp_firewalld module

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Ensure that all addresses are normalized when rules are processed
- Remove nested looped rule normalization of addresses since it is no longer
  required
- Fix normalize_addresses() so that it simply grabs the netmask if present and
  slaps on the appropriate one if not

SIMP-8328 #comment Fix issue with iptables address normalization