### PR TITLE
(SIMP-8613) appropriately configure firewalld

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Oct 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.5.3
+- Ensure that systems that do not have firewalld will not attempt to configure
+  it.
+
 * Tue Sep 29 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.5.2
 - Fix README.md inaccuracies
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ systems based on regular expression matches.
 The module manages the ``iptables`` package, service, and rules.
 
 On systems containing the ``firewalld`` service, it is ensured to be stopped
-unless ``iptables::use_firewalld`` is set to ``true`` or ``iptables::enable`` is
-set to ``firewalld``.
+unless ``iptables::use_firewalld`` is set to ``true``.
 
 ### Beginning with iptables
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -77,7 +77,7 @@ Data type: `Variant[Enum['ignore','firewalld'],Boolean]`
 
 Enable IPTables
 
-* If set to ``firewalld`` will enable management of the firewall via ``simp_firewalld``
+* If set to ``true`` will **enable** management of IPTables
 * If set to ``false`` will **disable** IPTables completely
 * If set to ``ignore`` will stop managing IPTables
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -49,11 +49,10 @@
 
 ----------
 
-> It is **highly recommended** that you place this module in
-> ``firewalld`` mode if the underlying system supports it.
+> It is **highly recommended** that you place this module in ``firewalld``
+> mode if the underlying system supports it.
 >
-> You can do this by setting ``simp_options::firewall: firewalld` or
-> `iptables::enable: firewalld` in Hiera
+> You can do this by setting ``iptables::use_firewalld: true`` in Hiera
 
 ----------
 
@@ -88,7 +87,9 @@ Default value: `simplib::lookup('simp_options::firewall', { 'default_value' => t
 
 Data type: `Boolean`
 
-**EXPERIMENTAL** Enable the firewalld-passthrough capabilties
+Explicitly enable management via ``simp_firewalld``
+
+* Systems that do not have ``firewalld`` installed will fall back to ``iptables``
 
 Default value: `iptables::use_firewalld($enable)`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,11 +2,10 @@
 #
 # ----------
 #
-# > It is **highly recommended** that you place this module in
-# > ``firewalld`` mode if the underlying system supports it.
+# > It is **highly recommended** that you place this module in ``firewalld``
+# > mode if the underlying system supports it.
 # >
-# > You can do this by setting ``simp_options::firewall: firewalld` or
-# > `iptables::enable: firewalld` in Hiera
+# > You can do this by setting ``iptables::use_firewalld: true`` in Hiera
 #
 # ----------
 #
@@ -29,7 +28,9 @@
 #   * If set to ``ignore`` will stop managing IPTables
 #
 # @param use_firewalld
-#   **EXPERIMENTAL** Enable the firewalld-passthrough capabilties
+#   Explicitly enable management via ``simp_firewalld``
+#
+#   * Systems that do not have ``firewalld`` installed will fall back to ``iptables``
 #
 # @param ensure
 #   The state that the ``package`` resources should target

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@
 # @param enable
 #   Enable IPTables
 #
-#   * If set to ``firewalld`` will enable management of the firewall via ``simp_firewalld``
+#   * If set to ``true`` will **enable** management of IPTables
 #   * If set to ``false`` will **disable** IPTables completely
 #   * If set to ``ignore`` will stop managing IPTables
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,7 +120,7 @@ class iptables (
   simplib::assert_metadata($module_name)
 
   if $enable != 'ignore' {
-    if $use_firewalld {
+    if ( 'firewalld' in pick($facts['simplib__firewalls'], 'none') ) and $use_firewalld {
       simplib::assert_optional_dependency($module_name, 'simp/simp_firewalld')
 
       include 'simp_firewalld'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -91,7 +91,6 @@ describe 'iptables' do
             it { is_expected.to raise_error(/param/) }
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
Fixed:
  * Ensure that firewalld is only enabled on systems that have it
    installed.

SIMP-8613 #close