### PR TITLE
(SIMP-9432) Fix EL8 packages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Wed Mar 10 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.5.5
+- Fixed
+  - Moved the service-relevant files out of `install` and into `service`
+  - Ensure that EL8+ installs `iptables-service` instead of trying to install
+    the EL7 packages
+  - Call `iptables::install` in all enabled modes since `firewalld` may require
+    the underlying packages
+
 * Thu Jan 07 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.5.5
 - Removed EL6 support
 

--- a/data/os/CentOS-7.yaml
+++ b/data/os/CentOS-7.yaml
@@ -1,0 +1,3 @@
+---
+iptables::install::ipv4_package: iptables
+iptables::install::ipv6_package: iptables-ipv6

--- a/data/os/CentOS.yaml
+++ b/data/os/CentOS.yaml
@@ -1,0 +1,4 @@
+---
+# EL8+
+iptables::install::ipv4_package: iptables-services
+iptables::install::ipv6_package: iptables-services

--- a/data/os/OracleLinux-7.yaml
+++ b/data/os/OracleLinux-7.yaml
@@ -1,0 +1,3 @@
+---
+iptables::install::ipv4_package: iptables
+iptables::install::ipv6_package: iptables-ipv6

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -1,0 +1,4 @@
+---
+# EL8+
+iptables::install::ipv4_package: iptables-services
+iptables::install::ipv6_package: iptables-services

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -1,0 +1,3 @@
+---
+iptables::install::ipv4_package: iptables
+iptables::install::ipv6_package: iptables-ipv6

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,4 @@
+---
+# EL8+
+iptables::install::ipv4_package: iptables-services
+iptables::install::ipv6_package: iptables-services

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,9 +1,0 @@
-simp::classes: [ '--yum' ]
-# Needed to ensure that the internal data references are valid
-simp::server::data: ['none']
-simp::vardir_owner: 'Administrators'
-simp::vardir_group: 'Administrators'
-simp::vardir_mode: '0770'
-
-# Unused but needs to be set
-simp::puppetdb::cipher_suites: []

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,0 +1,9 @@
+simp::classes: [ '--yum' ]
+# Needed to ensure that the internal data references are valid
+simp::server::data: ['none']
+simp::vardir_owner: 'Administrators'
+simp::vardir_group: 'Administrators'
+simp::vardir_mode: '0770'
+
+# Unused but needs to be set
+simp::puppetdb::cipher_suites: []

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,14 @@
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "OS + Release"
+    path: "os/%{facts.operatingsystem}-%{facts.operatingsystemmajrelease}.yaml"
+  - name: "OS"
+    path: "os/%{facts.operatingsystem}.yaml"
+  - name: "Kernel"
+    path: "os/%{facts.kernel}.yaml"
+  - name: "Common"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,9 @@ class iptables (
 
   $firewalld_mode = ( 'firewalld' in pick($facts['simplib__firewalls'], 'none') ) and $use_firewalld
   if $enable != 'ignore' {
+    # This is required in case you want to put firewalld in iptables mode
+    contain 'iptables::install'
+
     if $firewalld_mode {
       simplib::assert_optional_dependency($module_name, 'simp/simp_firewalld')
 
@@ -134,7 +137,6 @@ class iptables (
       }
     }
     else {
-      contain 'iptables::install'
       contain 'iptables::service'
 
       if $default_rules { contain 'iptables::rules::base' }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,6 +14,8 @@ class iptables::install (
   String[1] $ipv4_package,
   String[1] $ipv6_package
 ){
+  assert_private()
+
   simplib::assert_metadata($module_name)
 
   ensure_packages($ipv4_package, {'ensure' => $iptables::ensure})

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,63 +1,24 @@
-# **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
-#
 # Install the IPTables and IP6Tables components
 #
-# This also installs fallback startup scripts that come into play should the
-# regular processes fail to start due to a race consition with DNS.
+# @param ipv4_package
+#   The package used to manage ipv4 rules
 #
-class iptables::install {
-  assert_private()
+#   * Default from module data
+#
+# @param ipv6_package
+#   The package used to manage ipv6 rules
+#
+#   * Default from module data
+#
+class iptables::install (
+  String[1] $ipv4_package,
+  String[1] $ipv6_package
+){
   simplib::assert_metadata($module_name)
 
-  # IPV4-only stuff
-  package { 'iptables': ensure => $iptables::ensure }
-
-  file { '/etc/init.d/iptables':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-    content => file("${module_name}/iptables"),
-    seltype => 'iptables_initrc_exec_t'
-  }
-
-  # --------------------------------------------------
-  # Set the iptables startup script to fail safe.
-  #
-  file { '/etc/init.d/iptables-retry':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0744',
-    content => file("${module_name}/iptables-retry"),
-    seltype => 'iptables_initrc_exec_t'
-  }
-
-  Package['iptables'] -> File['/etc/init.d/iptables']
-  Package['iptables'] -> File['/etc/init.d/iptables-retry']
+  ensure_packages($ipv4_package, {'ensure' => $iptables::ensure})
 
   if $iptables::ipv6 and $facts['ipv6_enabled'] {
-    # IPV6-only stuff
-    file { '/etc/init.d/ip6tables':
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0755',
-      seltype => 'iptables_initrc_exec_t',
-      content => file("${module_name}/ip6tables")
-    }
-
-    file { '/etc/init.d/ip6tables-retry':
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0744',
-      seltype => 'iptables_initrc_exec_t',
-      content => file("${module_name}/ip6tables-retry")
-    }
-
-    package { 'iptables-ipv6': ensure => $iptables::ensure }
-    Package['iptables-ipv6'] -> File['/etc/init.d/ip6tables']
-    Package['iptables-ipv6'] -> File['/etc/init.d/ip6tables-retry']
+    ensure_packages($ipv6_package, {'ensure' => $iptables::ensure})
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,5 +1,8 @@
 # Manage the IPTables and IP6Tables services
 #
+# This also installs fallback startup scripts that come into play should the
+# regular processes fail to start due to a race condition with DNS.
+#
 # @param enable
 #   Enable IPTables
 #
@@ -25,21 +28,61 @@ class iptables::service (
       $_enable = false
     }
 
+    file { '/etc/init.d/iptables':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => file("${module_name}/iptables"),
+      seltype => 'iptables_initrc_exec_t'
+    }
+
+    # --------------------------------------------------
+    # Set the iptables startup script to fail safe.
+    #
+    file { '/etc/init.d/iptables-retry':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0744',
+      content => file("${module_name}/iptables-retry"),
+      seltype => 'iptables_initrc_exec_t'
+    }
+
     service { 'iptables':
       ensure     => $_ensure,
       enable     => $_enable,
       hasrestart => false,
       restart    => '/sbin/iptables-restore /etc/sysconfig/iptables || ( /sbin/iptables-restore /etc/sysconfig/iptables.bak && exit 3 )',
       hasstatus  => true,
+      require    => File['/etc/init.d/iptables'],
       provider   => 'redhat'
     }
 
     service { 'iptables-retry':
       enable   => $_enable,
+      require  => File['/etc/init.d/iptables-retry'],
       provider => 'redhat'
     }
 
     if $ipv6 and $facts['ipv6_enabled'] {
+      file { '/etc/init.d/ip6tables':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        seltype => 'iptables_initrc_exec_t',
+        content => file("${module_name}/ip6tables")
+      }
+
+      file { '/etc/init.d/ip6tables-retry':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0744',
+        seltype => 'iptables_initrc_exec_t',
+        content => file("${module_name}/ip6tables-retry")
+      }
       service { 'ip6tables':
         ensure     => $_ensure,
         enable     => $_enable,

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -19,7 +19,7 @@ HOSTS:
     roles:
       - firewalld
     platform: el-8-x86_64
-    box: generic/centos8
+    box: centos/8
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,7 @@ describe 'iptables' do
           it { is_expected.to create_class('iptables').with_enable(true) }
 
           if os_facts[:os][:release][:major] != '8'
-            it { is_expected.to contain_package('iptables').with_ensure('installed') }
+            it { is_expected.to contain_package('iptables').with_ensure('present') }
             it { is_expected.to contain_service('iptables').with_ensure('running') }
             it { is_expected.to contain_service('iptables-retry').with_enable(true) }
             it { is_expected.to create_class('iptables::rules::base').with_allow_ping(true) }
@@ -36,7 +36,9 @@ describe 'iptables' do
           else
             it { is_expected.to create_class('simp_firewalld') }
             it { is_expected.to_not create_iptables__ports('firewalld') }
-            it { is_expected.to_not create_class('iptables::install') }
+            it { is_expected.not_to contain_package('iptables') }
+            it { is_expected.not_to contain_package('iptables-ipv6') }
+            it { is_expected.to contain_package('iptables-services').with_ensure('present') }
             it { is_expected.to_not create_class('iptables::service') }
             it { is_expected.to_not create_class('iptables::rules::default_drop') }
             it { is_expected.to_not create_file('/etc/sysconfig/iptables') }
@@ -57,7 +59,7 @@ describe 'iptables' do
           it { is_expected.to create_class('iptables').with_enable(true) }
 
           it { is_expected.to create_class('simp_firewalld') }
-          it { is_expected.to_not create_class('iptables::install') }
+          it { is_expected.to create_class('iptables::install') }
           it { is_expected.to_not create_class('iptables::service') }
         end
 


### PR DESCRIPTION
- Fixed
  - Moved the service-relevant files out of `install` and into `service`
  - Ensure that EL8+ installs `iptables-service` instead of trying to install
    the EL7 packages
  - Call `iptables::install` in all enabled modes since `firewalld` may require
    the underlying packages