### PR TITLE
Remove gating logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Aug 07 2023 Steven Pritchard <steve@sicura.us> - 6.9.0
+- Remove extra gating logic in `iptables` class
+
 * Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.8.0
 - Add RockyLinux 8 support
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,15 +117,13 @@ class iptables (
   Boolean                         $prevent_localhost_spoofing = true,
   Optional[Hash]                  $ports                      = undef
 ) {
-
   simplib::assert_metadata($module_name)
 
-  $firewalld_mode = ( 'firewalld' in pick($facts['simplib__firewalls'], 'none') ) and $use_firewalld
   if $enable != 'ignore' {
     # This is required in case you want to put firewalld in iptables mode
     contain 'iptables::install'
 
-    if $firewalld_mode {
+    if $use_firewalld {
       simplib::assert_optional_dependency($module_name, 'simp/simp_firewalld')
 
       include 'simp_firewalld'
@@ -135,8 +133,7 @@ class iptables (
           ports => $ports
         }
       }
-    }
-    else {
+    } else {
       contain 'iptables::service'
 
       if $default_rules { contain 'iptables::rules::base' }

--- a/manifests/listen/all.pp
+++ b/manifests/listen/all.pp
@@ -70,7 +70,7 @@ define iptables::listen::all (
 ){
   include 'iptables'
 
-  if $iptables::firewalld_mode {
+  if $iptables::use_firewalld {
     simplib::assert_optional_dependency($module_name, 'simp/simp_firewalld')
 
     simp_firewalld::rule { "all_${name}":

--- a/manifests/listen/icmp.pp
+++ b/manifests/listen/icmp.pp
@@ -80,7 +80,7 @@ define iptables::listen::icmp (
 ) {
   include 'iptables'
 
-  if $iptables::firewalld_mode {
+  if $iptables::use_firewalld {
     simplib::assert_optional_dependency($module_name, 'simp/simp_firewalld')
 
     simp_firewalld::rule { "icmp_${name}":

--- a/manifests/listen/tcp_stateful.pp
+++ b/manifests/listen/tcp_stateful.pp
@@ -77,7 +77,7 @@ define iptables::listen::tcp_stateful (
 ) {
   include 'iptables'
 
-  if $iptables::firewalld_mode {
+  if $iptables::use_firewalld {
     simplib::assert_optional_dependency($module_name, 'simp/simp_firewalld')
 
     simp_firewalld::rule { "tcp_${name}":

--- a/manifests/listen/udp.pp
+++ b/manifests/listen/udp.pp
@@ -77,7 +77,7 @@ define iptables::listen::udp (
 ) {
   include 'iptables'
 
-  if $iptables::firewalld_mode {
+  if $iptables::use_firewalld {
     simplib::assert_optional_dependency($module_name, 'simp/simp_firewalld')
 
     simp_firewalld::rule { "udp_${name}":

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -83,7 +83,7 @@ define iptables::rule (
 ) {
   include iptables
 
-  if $iptables::firewalld_mode {
+  if $iptables::use_firewalld {
     $_caller = simplib::caller()
 
     notify { 'iptables::rule with firewalld':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",


### PR DESCRIPTION
Remove the logic from the `iptables` class that prevents the class from using `firewalld` when it has been requested (via `iptables::use_firewalld`) but has not been installed yet.