### PR TITLE
Cleanup metadata for 8.0.0 release

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -127,9 +127,6 @@ jobs:
           - docker_oel8
           - docker_oel9
           - docker_oel10
-          - docker_rhel8
-          - docker_rhel9
-          - docker_rhel10
           - docker_rocky8
           - docker_rocky9
           - docker_rocky10

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -10,9 +10,9 @@
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake parallel_spec'
+      - run: 'bundle exec rake spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:
@@ -127,6 +127,9 @@ jobs:
           - docker_oel8
           - docker_oel9
           - docker_oel10
+          - docker_rhel8
+          - docker_rhel9
+          - docker_rhel10
           - docker_rocky8
           - docker_rocky9
           - docker_rocky10
@@ -147,4 +150,4 @@ jobs:
           echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
       - name: beaker
         run: |
-          bundle exec rake beaker:suites[firewalld,${{ matrix.node }}]
+          bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -150,4 +150,4 @@ jobs:
           echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
       - name: beaker
         run: |
-          bundle exec rake beaker:suites[default,${{ matrix.node }}]
+          bundle exec rake beaker:suites[firewalld,${{ matrix.node }}]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Remove unmaintained Compliance Engine data
 - Drop support for end-of-life Amazon Linux 2
 - Drop Puppet 7 support; require openvox >= 8 < 9
+- Point `issues_url` at GitHub Issues; allow `simp-simplib` 5.x.
 
 * Thu Nov 20 2025 Steven Pritchard <steve@sicura.us> - 7.1.2
 - Drop unmaintained `.gitlab-ci.yml`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -644,7 +644,7 @@ The following parameters are available in the `iptables::service` class:
 
 ##### <a name="-iptables--service--enable"></a>`enable`
 
-Data type: `Any`
+Data type: `Variant[Enum['ignore','firewalld'],Boolean]`
 
 Enable IPTables
 
@@ -655,7 +655,7 @@ Default value: `pick(getvar('iptables::enable'),true)`
 
 ##### <a name="-iptables--service--ipv6"></a>`ipv6`
 
-Data type: `Any`
+Data type: `Boolean`
 
 Also manage IP6Tables
 
@@ -1514,7 +1514,7 @@ The following properties are available in the `iptables_rule` type.
 
 ##### `content`
 
-Valid values: `/\w+/`
+Valid values: `%r{\w+}`
 
 The content of the rule that should be added
 
@@ -1616,7 +1616,7 @@ The name of the rule. Simply used for creating the unique fragments.
 
 ##### <a name="-iptables_rule--order"></a>`order`
 
-Valid values: `/\d+/`
+Valid values: `%r{\d+}`
 
 The order in which the rule should appear. 1 is the
 minimum and 999 is the max.
@@ -1662,7 +1662,7 @@ The following properties are available in the `xt_recent` type.
 
 ##### `ip_list_gid`
 
-Valid values: `/^\d+$/`
+Valid values: `%r{^\d+$}`
 
 Numerical GID for ownership of /proc/net/xt_recent/* files.
 
@@ -1670,7 +1670,7 @@ Default value: `0`
 
 ##### `ip_list_hash_size`
 
-Valid values: `/^\d+$/`
+Valid values: `%r{^\d+$}`
 
 Hash table size. 0 means to calculate it based on ip_list_tot.
 
@@ -1678,7 +1678,7 @@ Default value: `0`
 
 ##### `ip_list_perms`
 
-Valid values: `/^[0-7]{4}$/`
+Valid values: `%r{^[0-7]{4}$}`
 
 Permissions for /proc/net/xt_recent/* files.
 
@@ -1686,7 +1686,7 @@ Default value: `0640`
 
 ##### `ip_list_tot`
 
-Valid values: `/^\d+$/`
+Valid values: `%r{^\d+$}`
 
 The number of addresses remembered per table. This effectively
 becomes the maximum size of your block list. Be aware that
@@ -1696,7 +1696,7 @@ Default value: `100`
 
 ##### `ip_list_uid`
 
-Valid values: `/^\d+$/`
+Valid values: `%r{^\d+$}`
 
 Numerical UID for ownership of /proc/net/xt_recent/* files.
 
@@ -1704,7 +1704,7 @@ Default value: `0`
 
 ##### `ip_pkt_list_tot`
 
-Valid values: `/^\d+$/`
+Valid values: `%r{^\d+$}`
 
 The number of packets per address remembered.
 

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-iptables",
   "project_page": "https://github.com/simp/pupmod-simp-iptables",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-iptables/issues",
   "tags": [
     "compliance",
     "disa_stig",
@@ -24,7 +24,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/nodesets/almalinux10.yml
+++ b/spec/acceptance/nodesets/almalinux10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: almalinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/centos10.yml
+++ b/spec/acceptance/nodesets/centos10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/centos10s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel10.yml
+++ b/spec/acceptance/nodesets/oel10.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/oracle10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel10.yml
+++ b/spec/acceptance/nodesets/rhel10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/rhel10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky10.yml
+++ b/spec/acceptance/nodesets/rocky10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: rockylinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky9.yml
+++ b/spec/acceptance/nodesets/rocky9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: rockylinux/9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"


### PR DESCRIPTION
## Summary

Small metadata cleanups on top of the 8.0.0 release work already in master:

- Point `issues_url` at GitHub Issues instead of the retired Atlassian instance.
- Allow `simp-simplib` 5.x as a dependency.

## Test plan
- [x] `bundle exec rake metadata_lint` (ruby:3.2 container)