### PR TITLE
Fix duplicate Notify declaration in iptables::rule (firewalld mode)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Fri Jul 03 2026 Steven Pritchard <steve@sicura.us> - 8.0.2
-- Fix duplicate declaration of the firewalld-mode warning in `iptables::rule`
-  by making the notify title unique per rule instance
+- Fix the firewalld-mode warning in `iptables::rule`: the static-titled
+  notify resource caused duplicate-declaration failures with multiple rules
+  and broke idempotency on every run; use a compile-time warning() instead
 
 * Thu Jul 02 2026 Steven Pritchard <steve@sicura.us> - 8.0.1
 - Allow simp-simp_firewalld 2.x

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 * Fri Jul 03 2026 Steven Pritchard <steve@sicura.us> - 8.0.2
-- Fix the firewalld-mode warning in `iptables::rule`: the static-titled
-  notify resource caused duplicate-declaration failures with multiple rules
-  and broke idempotency on every run; use a compile-time warning() instead
+- Fix duplicate declaration of the firewalld-mode warning in `iptables::rule`
+  by including the rule name in the notify title
 
 * Thu Jul 02 2026 Steven Pritchard <steve@sicura.us> - 8.0.1
 - Allow simp-simp_firewalld 2.x

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jul 03 2026 Steven Pritchard <steve@sicura.us> - 8.0.2
+- Fix duplicate declaration of the firewalld-mode warning in `iptables::rule`
+  by making the notify title unique per rule instance
+
 * Thu Jul 02 2026 Steven Pritchard <steve@sicura.us> - 8.0.1
 - Allow simp-simp_firewalld 2.x
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -86,7 +86,7 @@ define iptables::rule (
   if $iptables::use_firewalld {
     $_caller = simplib::caller()
 
-    notify { 'iptables::rule with firewalld':
+    notify { "iptables::rule with firewalld (${name})":
       message  => "iptables::rule cannot be used directly in firewalld mode, please use simp_firewalld::rule => Called from ${_caller}",
       loglevel => 'warning'
     }

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -86,10 +86,12 @@ define iptables::rule (
   if $iptables::use_firewalld {
     $_caller = simplib::caller()
 
-    # Use a compile-time warning rather than a notify resource: a notify
-    # reports a change on every run, which breaks idempotency for any
-    # catalog using iptables::rule in firewalld mode
-    warning("iptables::rule cannot be used directly in firewalld mode, please use simp_firewalld::rule => Called from ${_caller}")
+    # Include the rule name in the title so that multiple iptables::rule
+    # declarations do not collide on a duplicate Notify declaration
+    notify { "iptables::rule with firewalld (${name})":
+      message  => "iptables::rule cannot be used directly in firewalld mode, please use simp_firewalld::rule => Called from ${_caller}",
+      loglevel => 'warning'
+    }
   }
   else {
     iptables_rule { $name:

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -86,10 +86,10 @@ define iptables::rule (
   if $iptables::use_firewalld {
     $_caller = simplib::caller()
 
-    notify { "iptables::rule with firewalld (${name})":
-      message  => "iptables::rule cannot be used directly in firewalld mode, please use simp_firewalld::rule => Called from ${_caller}",
-      loglevel => 'warning'
-    }
+    # Use a compile-time warning rather than a notify resource: a notify
+    # reports a change on every run, which breaks idempotency for any
+    # catalog using iptables::rule in firewalld mode
+    warning("iptables::rule cannot be used directly in firewalld mode, please use simp_firewalld::rule => Called from ${_caller}")
   }
   else {
     iptables_rule { $name:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-iptables",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "author": "SIMP Team",
   "summary": "Safely manages IPTables firewall rules",
   "license": "Apache-2.0",

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -23,8 +23,11 @@ describe 'iptables::rule', type: :define do
         if os_facts[:os][:release][:major].to_i < 8
           it { is_expected.to create_iptables_rule(title) }
         else
-          # In firewalld mode iptables::rule is a warned no-op
-          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to create_notify("iptables::rule with firewalld (#{title})")
+              .with_message(%r{cannot be used.+Called from})
+              .with_loglevel('warning')
+          }
           it { is_expected.not_to create_iptables_rule(title) }
         end
       end
@@ -32,9 +35,28 @@ describe 'iptables::rule', type: :define do
       context 'when explicitly using firewalld' do
         let(:hieradata) { 'firewall__firewalld' }
 
-        # In firewalld mode iptables::rule is a warned no-op
-        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to create_notify("iptables::rule with firewalld (#{title})")
+            .with_message(%r{cannot be used.+Called from})
+            .with_loglevel('warning')
+        }
         it { is_expected.not_to create_iptables_rule(title) }
+
+        # Multiple iptables::rule declarations must not collide on a
+        # duplicate Notify declaration in firewalld mode
+        context 'with multiple iptables::rule declarations' do
+          let(:pre_condition) do
+            <<~PP
+              iptables::rule { 'second_rule': content => 'bar' }
+              iptables::rule { 'third_rule': content => 'baz' }
+            PP
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_notify("iptables::rule with firewalld (#{title})") }
+          it { is_expected.to create_notify('iptables::rule with firewalld (second_rule)') }
+          it { is_expected.to create_notify('iptables::rule with firewalld (third_rule)') }
+        end
       end
     end
   end

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -23,22 +23,18 @@ describe 'iptables::rule', type: :define do
         if os_facts[:os][:release][:major].to_i < 8
           it { is_expected.to create_iptables_rule(title) }
         else
-          it {
-            is_expected.to create_notify('iptables::rule with firewalld')
-              .with_message(%r{cannot be used.+Called from})
-              .with_loglevel('warning')
-          }
+          # In firewalld mode iptables::rule is a warned no-op
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to create_iptables_rule(title) }
         end
       end
 
       context 'when explicitly using firewalld' do
         let(:hieradata) { 'firewall__firewalld' }
 
-        it {
-          is_expected.to create_notify('iptables::rule with firewalld')
-            .with_message(%r{cannot be used.+Called from})
-            .with_loglevel('warning')
-        }
+        # In firewalld mode iptables::rule is a warned no-op
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to create_iptables_rule(title) }
       end
     end
   end


### PR DESCRIPTION
The firewalld-mode warning in `iptables::rule` used a static resource title, so any catalog declaring more than one `iptables::rule` in firewalld mode failed compilation with:

```
Duplicate declaration: Notify[iptables::rule with firewalld] is already declared
```

(Surfaced by pupmod-simp-libreswan's acceptance suite, which declares several rules.)

- Include the rule name in the notify title to make it unique per instance (keeping the agent-visible notify per review)
- Regression test: multiple `iptables::rule` declarations in firewalld mode must compile, each with its own notify
- Bump version to 8.0.2 with CHANGELOG entry

**Reviewer note:** a notify resource reports a change on every Puppet run, so catalogs using `iptables::rule` in firewalld mode will not pass `catch_changes`-style idempotency checks. That trade-off is accepted here; consumer test suites should use `simp_firewalld::rule` directly in firewalld mode (libreswan's suite was updated accordingly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)